### PR TITLE
git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Q_Pansopy.zip


### PR DESCRIPTION
just to make it easy to not track the zip file that becomes the plugin