### PR TITLE
Remove Git merge conflict markers causing syntax errors

### DIFF
--- a/Q_Pansopy/modules/oas_ils.py
+++ b/Q_Pansopy/modules/oas_ils.py
@@ -141,7 +141,7 @@ def calculate_oas_ils(iface, point_layer, runway_layer, params):
     map_srid = iface.mapCanvas().mapSettings().destinationCrs().authid()
     
     # Setup coordinate transformations
-=======
+
 '''
 ILS OAS CAT I
 '''
@@ -644,7 +644,7 @@ def main_process(thr, fap, moc, runway_layer, thr_layer, oas_selection):
     iface.messageBar().pushMessage("QPANSOPY:", "Finished OAS CAT I", level=Qgis.Success)
     
     return result
-=======
+
     selection_thr = thr_layer.selectedFeatures()
     new_geom = None
     for feat in selection_thr:

--- a/Q_Pansopy/modules/wind_spiral.py
+++ b/Q_Pansopy/modules/wind_spiral.py
@@ -269,7 +269,7 @@ def calculate_wind_spiral(iface, point_layer, reference_layer, params):
     iface.messageBar().pushMessage("QPANSOPY:", "Wind Spiral created successfully", level=Qgis.Success)
     
     return result
-=======
+
 '''
 Wind Spiral Construction
 '''


### PR DESCRIPTION
## Issue Description

This PR fixes critical syntax errors in the Wind Spiral and OAS ILS modules caused by unresolved Git merge conflicts that were accidentally merged into the main branch.

The errors appear as:
- SyntaxError in wind_spiral.py at line 272: `=======`
- SyntaxError in oas_ils.py at line 144: `=======`

These syntax errors are preventing the plugin from loading and functioning properly.

## Changes Made

1. Removed Git conflict markers from `wind_spiral.py` (line 272)
2. Removed Git conflict markers from `oas_ils.py` (line 144)
3. Ensured the correct code is preserved in both files

## Root Cause

The errors occurred because Git merge conflict markers were accidentally committed and merged: