### PR TITLE
Issue #87: Fix KML Export for OAS ILS CAT I Generator

### DIFF
--- a/Q_Pansopy/modules/oas_ils.py
+++ b/Q_Pansopy/modules/oas_ils.py
@@ -19,7 +19,7 @@ import datetime
 import json
 import numpy as np
 import re
-from ..utils import get_selected_feature
+from ..utils import get_selected_feature, fix_kml_altitude_mode
 
 # Global variables to store computed values
 OAS_template = None


### PR DESCRIPTION
# Summary - Issue #87: Fix KML Export for OAS ILS CAT I Generator
## Problem
### When exporting OAS ILS CAT I surfaces to KML, the 3D areas were being displayed flat on the ground in Google Earth instead of at their correct altitudes.

## Solution
### Added a fix that ensures exported KML files display surfaces at their actual elevations (absolute altitude mode), so the 3D obstacle assessment surfaces appear correctly in Google Earth.

### Files Changed

- [utils.py](vscode-file://vscode-app/c:/Users/andre/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) - Added utility function to fix altitude mode in KML files
- [oas_ils.py](vscode-file://vscode-app/c:/Users/andre/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) - Applied the fix after KML export