### PR TITLE
Fix/issue 110 hide log when disabled

### DIFF
--- a/Q_Pansopy/qpansopy.py
+++ b/Q_Pansopy/qpansopy.py
@@ -713,6 +713,11 @@ class Qpansopy:
             self.settings.setValue("qpansopy/enable_kml", vals["enable_kml"])
             self.settings.setValue("qpansopy/show_log", vals["show_log"])
             self.settings_values = vals
+            # Apply log visibility immediately to all existing docks
+            try:
+                self._apply_log_visibility(vals["show_log"])
+            except Exception:
+                pass
 
     def create_callback(self, name):
         """Create a callback function for the given module name"""
@@ -770,3 +775,30 @@ class Qpansopy:
                 self.iface.messageBar().pushMessage("QPANSOPY", f"Merge failed: {e}", level=_Q.Critical)
             except Exception:
                 pass
+
+    def _apply_log_visibility(self, show_log: bool):
+        """Apply log visibility setting to all instantiated docks."""
+        for name, props in getattr(self, "modules", {}).items():
+            inst = props.get("GUI_INSTANCE")
+            if not inst:
+                continue
+            try:
+                log_widget = getattr(inst, "logTextEdit", None)
+                log_group = None
+                parent = log_widget.parentWidget() if log_widget else None
+                while parent is not None and not isinstance(parent, QtWidgets.QGroupBox):
+                    parent = parent.parentWidget()
+                if isinstance(parent, QtWidgets.QGroupBox):
+                    log_group = parent
+                if log_group:
+                    log_group.setVisible(show_log)
+                if log_widget:
+                    log_widget.setVisible(show_log)
+                # When re-showing, ensure resizable behavior is restored
+                if show_log:
+                    try:
+                        self._ensure_resizable_log(inst)
+                    except Exception:
+                        pass
+            except Exception:
+                continue


### PR DESCRIPTION
# Summary
Implements the requested behavior to completely hide the “Log” section from all dock panels when “Show log box by default” is disabled in Settings. This removes UI confusion by ensuring no log UI is shown anywhere while the setting is off, and restores the log (including its resize handle) when re-enabled.

# Related Issue

Closes #110