### PR TITLE
Fix Feature Merge Import Error (#65)

### DIFF
--- a/Q_Pansopy/modules/utilities/feature_merge.py
+++ b/Q_Pansopy/modules/utilities/feature_merge.py
@@ -24,7 +24,7 @@ Procedure Analysis and Obstacle Protection Surfaces - Feature Merge Module
 import os
 from qgis.core import (
     QgsProject, QgsVectorLayer, QgsWkbTypes, QgsFeature,
-    QgsFields, QgsField, QgsFeatureRequest
+    QgsFields, QgsField, QgsFeatureRequest, Qgis
 )
 from PyQt5.QtCore import QVariant
 


### PR DESCRIPTION
# Description
Fixes NameError in feature merge utility when Qgis enum is referenced but not imported.