### PR TITLE
 Prevent QGIS window resize when switching between plugin #39

### DIFF
--- a/Q_Pansopy/dockwidgets/departures/qpansopy_omnidirectional_dockwidget.py
+++ b/Q_Pansopy/dockwidgets/departures/qpansopy_omnidirectional_dockwidget.py
@@ -51,7 +51,7 @@ class QPANSOPYOmnidirectionalDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
             self.setAllowedAreas(Qt.LeftDockWidgetArea | Qt.RightDockWidgetArea)
         except Exception:
             pass
-        self.setMinimumHeight(300)
+        # Don't set minimum height - let dock adjust naturally to prevent QGIS window resize
         
         # Connect signals
         self.calculateButton.clicked.connect(self.calculate)

--- a/Q_Pansopy/dockwidgets/departures/qpansopy_sid_initial_dockwidget.py
+++ b/Q_Pansopy/dockwidgets/departures/qpansopy_sid_initial_dockwidget.py
@@ -78,7 +78,7 @@ class QPANSOPYSIDInitialDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         except Exception:
             pass
         
-        self.setMinimumHeight(300)
+        # Don't set minimum height - let dock adjust naturally to prevent QGIS window resize
         
         # Setup layer combobox
         self.runwayLayerComboBox.setFilters(QgsMapLayerProxyModel.LineLayer)

--- a/Q_Pansopy/ui/departures/qpansopy_omnidirectional_dockwidget.ui
+++ b/Q_Pansopy/ui/departures/qpansopy_omnidirectional_dockwidget.ui
@@ -4,14 +4,14 @@
  <widget class="QDockWidget" name="QPANSOPYOmnidirectionalDockWidget">
   <property name="minimumSize">
    <size>
-    <width>280</width>
-    <height>400</height>
+    <width>250</width>
+    <height>200</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
     <width>16777215</width>
-    <height>550</height>
+    <height>16777215</height>
    </size>
   </property>
   <widget class="QWidget" name="dockWidgetContents">

--- a/Q_Pansopy/ui/departures/qpansopy_sid_initial_dockwidget.ui
+++ b/Q_Pansopy/ui/departures/qpansopy_sid_initial_dockwidget.ui
@@ -2,23 +2,15 @@
 <ui version="4.0">
  <class>QPANSOPYSIDInitialDockWidget</class>
  <widget class="QDockWidget" name="QPANSOPYSIDInitialDockWidget">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>260</width>
-    <height>420</height>
-   </rect>
-  </property>
   <property name="minimumSize">
    <size>
-    <width>240</width>
-    <height>350</height>
+    <width>250</width>
+    <height>200</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
-    <width>320</width>
+    <width>16777215</width>
     <height>16777215</height>
    </size>
   </property>
@@ -388,41 +380,22 @@
      </layout>
     </item>
     <item>
-     <widget class="QLabel" name="logLabel">
-      <property name="text">
-       <string>Log:</string>
+     <widget class="QGroupBox" name="logGroup">
+      <property name="title">
+       <string>Log</string>
       </property>
-      <property name="font">
-       <font>
-        <weight>75</weight>
-        <bold>true</bold>
-       </font>
-      </property>
-     </widget>
-    </item>
-    <item>
-     <widget class="QTextEdit" name="logTextEdit">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>0</width>
-        <height>50</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>16777215</width>
-        <height>55</height>
-       </size>
-      </property>
-      <property name="readOnly">
-       <bool>true</bool>
-      </property>
+      <layout class="QVBoxLayout" name="logLayout">
+       <item>
+        <widget class="QTextEdit" name="logTextEdit">
+         <property name="readOnly">
+          <bool>true</bool>
+         </property>
+         <property name="minimumHeight">
+          <number>100</number>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </widget>
     </item>
     <item>

--- a/Q_Pansopy/ui/ils/qpansopy_ils_dockwidget.ui
+++ b/Q_Pansopy/ui/ils/qpansopy_ils_dockwidget.ui
@@ -2,18 +2,10 @@
 <ui version="4.0">
  <class>QPANSOPYILSDockWidget</class>
  <widget class="QDockWidget" name="QPANSOPYILSDockWidget">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>400</width>
-    <height>500</height>
-   </rect>
-  </property>
   <property name="minimumSize">
    <size>
-    <width>300</width>
-    <height>300</height>
+    <width>250</width>
+    <height>200</height>
    </size>
   </property>
     <property name="maximumSize">
@@ -154,7 +146,7 @@
         <item>
          <widget class="QGroupBox" name="groupBox_5">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>

--- a/Q_Pansopy/ui/ils/qpansopy_oas_ils_dockwidget.ui
+++ b/Q_Pansopy/ui/ils/qpansopy_oas_ils_dockwidget.ui
@@ -2,20 +2,18 @@
 <ui version="4.0">
  <class>QPANSOPYOASILSDockWidgetBase</class>
  <widget class="QDockWidget" name="QPANSOPYOASILSDockWidgetBase">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>400</width>
-    <height>600</height>
-   </rect>
+  <property name="minimumSize">
+   <size>
+    <width>250</width>
+    <height>200</height>
+   </size>
   </property>
-    <property name="minimumSize">
-     <size>
-        <width>0</width>
-        <height>0</height>
-     </size>
-    </property>
+  <property name="maximumSize">
+   <size>
+    <width>16777215</width>
+    <height>16777215</height>
+   </size>
+  </property>
   <property name="windowTitle">
    <string>QPANSOPY OAS ILS</string>
   </property>

--- a/Q_Pansopy/ui/pbn/qpansopy_gnss_waypoint_dockwidget.ui
+++ b/Q_Pansopy/ui/pbn/qpansopy_gnss_waypoint_dockwidget.ui
@@ -215,19 +215,13 @@
     <item>
      <widget class="QGroupBox" name="logGroup">
       <property name="sizePolicy">
-       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
         <horstretch>0</horstretch>
         <verstretch>0</verstretch>
        </sizepolicy>
       </property>
       <property name="title">
        <string>Log</string>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>16777215</width>
-        <height>95</height>
-       </size>
       </property>
       <layout class="QVBoxLayout" name="logLayout">
        <property name="spacing">
@@ -237,6 +231,9 @@
         <widget class="QTextEdit" name="logTextEdit">
          <property name="readOnly">
           <bool>true</bool>
+         </property>
+         <property name="minimumHeight">
+          <number>100</number>
          </property>
         </widget>
        </item>

--- a/Q_Pansopy/ui/utilities/qpansopy_feature_merge_dockwidget.ui
+++ b/Q_Pansopy/ui/utilities/qpansopy_feature_merge_dockwidget.ui
@@ -4,8 +4,8 @@
  <widget class="QDockWidget" name="QPANSOPYFeatureMergeDockWidget">
   <property name="minimumSize">
    <size>
-    <width>300</width>
-    <height>450</height>
+    <width>250</width>
+    <height>200</height>
    </size>
   </property>
     <property name="maximumSize">

--- a/Q_Pansopy/ui/utilities/qpansopy_holding_dockwidget.ui
+++ b/Q_Pansopy/ui/utilities/qpansopy_holding_dockwidget.ui
@@ -4,8 +4,14 @@
  <widget class="QDockWidget" name="QPANSOPYHoldingDockWidget">
   <property name="minimumSize">
    <size>
-    <width>280</width>
-    <height>260</height>
+    <width>250</width>
+    <height>200</height>
+   </size>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>16777215</width>
+    <height>16777215</height>
    </size>
   </property>
   <widget class="QWidget" name="dockWidgetContents">

--- a/Q_Pansopy/ui/utilities/qpansopy_point_filter_dockwidget.ui
+++ b/Q_Pansopy/ui/utilities/qpansopy_point_filter_dockwidget.ui
@@ -4,8 +4,8 @@
  <widget class="QDockWidget" name="QPANSOPYPointFilterDockWidget">
   <property name="minimumSize">
    <size>
-    <width>300</width>
-    <height>500</height>
+    <width>250</width>
+    <height>200</height>
    </size>
   </property>
    <property name="maximumSize">

--- a/Q_Pansopy/ui/utilities/qpansopy_vss_dockwidget.ui
+++ b/Q_Pansopy/ui/utilities/qpansopy_vss_dockwidget.ui
@@ -2,13 +2,17 @@
 <ui version="4.0">
  <class>QPANSOPYVSSDockWidget</class>
  <widget class="QDockWidget" name="QPANSOPYVSSDockWidget">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>400</width>
-    <height>700</height>
-   </rect>
+  <property name="minimumSize">
+   <size>
+    <width>250</width>
+    <height>200</height>
+   </size>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>16777215</width>
+    <height>16777215</height>
+   </size>
   </property>
   <property name="windowTitle">
    <string>QPANSOPY VSS</string>

--- a/Q_Pansopy/ui/utilities/qpansopy_wind_spiral_dockwidget.ui
+++ b/Q_Pansopy/ui/utilities/qpansopy_wind_spiral_dockwidget.ui
@@ -2,26 +2,18 @@
 <ui version="4.0">
  <class>QPANSOPYWindSpiralDockWidgetBase</class>
  <widget class="QDockWidget" name="QPANSOPYWindSpiralDockWidgetBase">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>440</width>
-    <height>720</height>
-   </rect>
-  </property>
   <property name="minimumSize">
    <size>
-    <width>420</width>
-    <height>650</height>
+    <width>250</width>
+    <height>200</height>
    </size>
   </property>
-    <property name="minimumSize">
-     <size>
-        <width>0</width>
-        <height>0</height>
-     </size>
-    </property>
+  <property name="maximumSize">
+   <size>
+    <width>16777215</width>
+    <height>16777215</height>
+   </size>
+  </property>
   <property name="windowTitle">
    <string>QPANSOPY Wind Spiral</string>
   </property>


### PR DESCRIPTION
# Summary
Resolves issue #39 where QGIS main window would resize unexpectedly and display geometry errors when switching between plugin dockwidgets. The fix implements QScrollArea wrappers for all dockwidgets, aggressive size constraints, optimized timing delays, and improved geometry pre-calculation. All dockwidgets now open smoothly without resizing the QGIS window, even on first use.