### PR TITLE
Fix/CONV Initial KML Export Not Working (Issue #134)

### DIFF
--- a/Q_Pansopy/dockwidgets/conv/qpansopy_conv_initial_dockwidget.py
+++ b/Q_Pansopy/dockwidgets/conv/qpansopy_conv_initial_dockwidget.py
@@ -98,8 +98,6 @@ class QPANSOPYConvInitialDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
 
             if result:
                 self.log("CONV Initial Approach Areas calculation completed successfully")
-                if export_kml:
-                    self.log(f"KML export written to: {output_dir}")
                 
         except Exception as e:
             self.log(f"Error during calculation: {str(e)}")

--- a/Q_Pansopy/modules/conv/conv_initial_approach.py
+++ b/Q_Pansopy/modules/conv/conv_initial_approach.py
@@ -10,7 +10,7 @@ from qgis.PyQt.QtCore import QVariant
 from math import *
 import os
 import datetime
-from ..utils import fix_kml_altitude_mode, fix_kml_polygon_fill_color
+from ...utils import fix_kml_altitude_mode, fix_kml_polygon_fill_color
 
 # Qt5 / Qt6 compatible field-type constants for QgsField constructors.
 # QGIS 3.34+ / Qt6 deprecates QVariant.Type; QMetaType.Type is the replacement.

--- a/Q_Pansopy/modules/conv/conv_initial_approach.py
+++ b/Q_Pansopy/modules/conv/conv_initial_approach.py
@@ -10,6 +10,7 @@ from qgis.PyQt.QtCore import QVariant
 from math import *
 import os
 import datetime
+from ..utils import fix_kml_altitude_mode, fix_kml_polygon_fill_color
 
 # Qt5 / Qt6 compatible field-type constants for QgsField constructors.
 # QGIS 3.34+ / Qt6 deprecates QVariant.Type; QMetaType.Type is the replacement.
@@ -288,7 +289,6 @@ def run_conv_initial_approach(iface, routing_layer, params=None, export_kml=Fals
             # KML export
             if export_kml and output_dir:
                 try:
-                    from ...utils import fix_kml_altitude_mode, fix_kml_polygon_fill_color
                     timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
                     kml_path = os.path.join(output_dir, f'conv_initial_approach_{timestamp}.kml')
                     crs = QgsCoordinateReferenceSystem("EPSG:4326")


### PR DESCRIPTION
# PR — CONV Initial KML Export Not Working (Issue #134)

## Summary

- Fixes KML export silently doing nothing when "Export to KML" is checked in the CONV Initial tool.
- Moves the `fix_kml_altitude_mode` / `fix_kml_polygon_fill_color` imports to module level so any import failure is surfaced immediately rather than swallowed inside the KML try-except.
- Removes a misleading dockwidget log line that said "KML export written to: …" regardless of whether the export actually succeeded.

## Root Cause

`fix_kml_altitude_mode` and `fix_kml_polygon_fill_color` were imported **inside** the KML export
try-except block (`from ...utils import …`). A relative-import failure at that location raises
an `ImportError` that is caught by the except clause, which shows a transient QGIS message-bar
warning that is easy to miss — leaving the user with no KML file and no clear error.

Moving the import to module level means a failure is caught at plugin load time (not buried deep
inside a calculation), and the functions are available throughout the module without re-importing
on every call.

## Changes

| File | Change |
|---|---|
| `Q_Pansopy/modules/conv/conv_initial_approach.py` | Move `fix_kml_altitude_mode`/`fix_kml_polygon_fill_color` import to module level; remove duplicate inline import |
| `Q_Pansopy/dockwidgets/conv/qpansopy_conv_initial_dockwidget.py` | Remove unconditional "KML export written to: …" log line (module message bar handles success/failure) |

## Test Plan

- [ ] Check "Export to KML", set an output folder, run — confirm a `.kml` file is created in the folder.
- [ ] Open the exported KML in Google Earth Pro — confirm polygons appear at absolute altitude with green fill.
- [ ] Uncheck "Export to KML" and run — confirm no KML file is written and no error appears.
- [ ] Enter a non-existent output folder path — confirm a Warning message appears on the QGIS message bar.

## Related

Closes #134.
