### PR TITLE
LNAV "Executing" Message Shows Before Validation (Issue #135)

### DIFF
--- a/Q_Pansopy/modules/pbn/lnav_final_approach.py
+++ b/Q_Pansopy/modules/pbn/lnav_final_approach.py
@@ -86,9 +86,6 @@ def run_final_approach(iface_param, routing_layer, export_kml=False, output_dir=
         # Initialize QGIS interface from parameter
         iface = iface_param
         
-        # Notify user of calculation start
-        iface.messageBar().pushMessage("QPANSOPY:", "Executing LNAV Final Approach (RNP APCH)", level=Qgis.Info)
-
         map_srid = iface.mapCanvas().mapSettings().destinationCrs().authid()
 
         routing_layer = _resolve_routing_layer(iface, routing_layer)
@@ -103,6 +100,8 @@ def run_final_approach(iface_param, routing_layer, export_kml=False, output_dir=
         if geom_data is None:
             return None
         start_point, end_point, azimuth, back_azimuth, length = geom_data
+
+        iface.messageBar().pushMessage("QPANSOPY:", "Executing LNAV Final Approach (RNP APCH)", level=Qgis.Info)
 
         # === ICAO-COMPLIANT PROTECTION AREA CALCULATION ===
         # Initialize coordinate point storage for polygon vertices

--- a/Q_Pansopy/modules/pbn/lnav_initial_approach.py
+++ b/Q_Pansopy/modules/pbn/lnav_initial_approach.py
@@ -96,8 +96,6 @@ def run_initial_approach(iface_param, routing_layer, export_kml=False, output_di
         # Use the passed iface parameter
         iface = iface_param
         
-        iface.messageBar().pushMessage("QPANSOPY:", "Executing LNAV Initial Approach (RNP APCH)", level=Qgis.Info)
-
         map_srid = iface.mapCanvas().mapSettings().destinationCrs().authid()
 
         routing_layer = _resolve_routing_layer(iface, routing_layer)
@@ -111,6 +109,8 @@ def run_initial_approach(iface_param, routing_layer, export_kml=False, output_di
         geom_data = _extract_segment_geom(iface, initial_features, 'initial')
         if geom_data is None:
             return None
+
+        iface.messageBar().pushMessage("QPANSOPY:", "Executing LNAV Initial Approach (RNP APCH)", level=Qgis.Info)
         start_point, end_point, azimuth, back_azimuth, length = geom_data
 
         # Calculate point coordinates using the original algorithm

--- a/Q_Pansopy/modules/pbn/lnav_intermediate_approach.py
+++ b/Q_Pansopy/modules/pbn/lnav_intermediate_approach.py
@@ -107,9 +107,6 @@ def run_intermediate_approach(iface_param, routing_layer, export_kml=False, outp
         # Initialize QGIS interface from parameter
         iface = iface_param
         
-        # Notify user of intermediate approach calculation start
-        iface.messageBar().pushMessage("QPANSOPY:", "Executing LNAV Intermediate Approach (RNP APCH)", level=Qgis.Info)
-
         map_srid = iface.mapCanvas().mapSettings().destinationCrs().authid()
 
         routing_layer = _resolve_routing_layer(iface, routing_layer)
@@ -124,6 +121,8 @@ def run_intermediate_approach(iface_param, routing_layer, export_kml=False, outp
         if geom_data is None:
             return None
         start_point, end_point, azimuth, back_azimuth, length = geom_data
+
+        iface.messageBar().pushMessage("QPANSOPY:", "Executing LNAV Intermediate Approach (RNP APCH)", level=Qgis.Info)
 
         # Calculate point coordinates using the original algorithm
         pts = {}

--- a/Q_Pansopy/modules/pbn/lnav_missed_approach.py
+++ b/Q_Pansopy/modules/pbn/lnav_missed_approach.py
@@ -109,8 +109,6 @@ def run_missed_approach(iface_param, routing_layer, export_kml=False, output_dir
         # Use the passed iface parameter
         iface = iface_param
         
-        iface.messageBar().pushMessage("QPANSOPY:", "Executing LNAV Missed Approach (RNP APCH)", level=Qgis.Info)
-
         map_srid = iface.mapCanvas().mapSettings().destinationCrs().authid()
 
         routing_layer = _resolve_routing_layer(iface, routing_layer)
@@ -124,6 +122,8 @@ def run_missed_approach(iface_param, routing_layer, export_kml=False, output_dir
         if not selected_features:
             iface.messageBar().pushMessage("No 'missed' segment found in routing layer", level=Qgis.Critical)
             return None
+
+        iface.messageBar().pushMessage("QPANSOPY:", "Executing LNAV Missed Approach (RNP APCH)", level=Qgis.Info)
             
         # Process the selected features - use the first valid missed segment found (original behavior)
         for feat in selected_features:


### PR DESCRIPTION
# PR — LNAV "Executing" Message Shows Before Validation (Issue #135)

## Summary

- Fixes the blue info bar "QPANSOPY: Executing LNAV … (RNP APCH)" appearing even when
  the calculation cannot proceed (e.g. no segment of the required type is selected).
- Applies the same fix to all four LNAV approach modules.

## Root Cause

In each module the `pushMessage("Executing …")` call was placed **before** the three
validation steps (`_resolve_routing_layer`, `_select_segment_features`,
`_extract_segment_geom`). Any early return from those checks would still leave the
"Executing" bar message visible, misleading the user into thinking a calculation ran.

## Fix

Move the "Executing" `pushMessage` to **after** all validation guards pass — immediately
before the geometry calculation begins. The message is now only shown when execution
will actually proceed.

## Changes

| File | Change |
|---|---|
| `Q_Pansopy/modules/pbn/lnav_initial_approach.py` | Move "Executing" message after `_extract_segment_geom` guard |
| `Q_Pansopy/modules/pbn/lnav_final_approach.py` | Move "Executing" message after `_extract_segment_geom` guard |
| `Q_Pansopy/modules/pbn/lnav_intermediate_approach.py` | Move "Executing" message after `_extract_segment_geom` guard |
| `Q_Pansopy/modules/pbn/lnav_missed_approach.py` | Move "Executing" message after `selected_features` empty check |

## Test Plan

- [ ] Select a routing feature that has no `segment='initial'` attribute. Click Initial. Confirm **no** "Executing" message appears — only the "No 'initial' segment found" Critical message.
- [ ] Select nothing. Click Initial. Confirm only the "Please select at least one segment" Critical message appears.
- [ ] Select a valid 'initial' segment. Click Initial. Confirm "Executing" message appears and calculation completes.
- [ ] Repeat for Final, Intermediate, and Missed approach types.

## Related

Closes #135.
