### PR TITLE
Arrival segment filter + Missed Approach import fix (Issues #136, #137)

### DIFF
--- a/Q_Pansopy/dockwidgets/pbn/qpansopy_lnav_dockwidget.py
+++ b/Q_Pansopy/dockwidgets/pbn/qpansopy_lnav_dockwidget.py
@@ -88,7 +88,7 @@ class QPANSOPYLNAVDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
                 approach_type = "Intermediate"
             elif self.missedRadioButton.isChecked():
                 self.log("Calculating Missed Approach...")
-                from ...modules.pbn.PBN_LNAV_Missed_Approach import run_missed_approach
+                from ...modules.pbn.lnav_missed_approach import run_missed_approach
                 result = run_missed_approach(self.iface, routing_layer, export_kml, output_dir)
                 approach_type = "Missed Approach"
             elif getattr(self, 'sidRadioButton', None) and self.sidRadioButton.isChecked():

--- a/Q_Pansopy/modules/pbn/pbn_rnav1_arrival.py
+++ b/Q_Pansopy/modules/pbn/pbn_rnav1_arrival.py
@@ -27,6 +27,7 @@ from qgis.core import (
 from qgis.PyQt.QtCore import QVariant
 import os
 import math
+from ._lnav_common import _resolve_routing_layer
 
 
 def run_rnav1_arrival(iface, routing_layer, params=None):
@@ -53,21 +54,11 @@ def run_rnav1_arrival(iface, routing_layer, params=None):
     output_dir = params.get('output_dir', None)
     
     try:
-        iface.messageBar().pushMessage(
-            "QPANSOPY:", 
-            "Executing RNAV 1 Arrival Segment", 
-            level=Qgis.Info
-        )
-
         # Get Projected Coordinate System
         map_srid = iface.mapCanvas().mapSettings().destinationCrs().authid()
 
+        routing_layer = _resolve_routing_layer(iface, routing_layer)
         if routing_layer is None:
-            iface.messageBar().pushMessage(
-                "Error", 
-                "No routing layer provided", 
-                level=Qgis.Critical
-            )
             return None
 
         # Get user's current selection
@@ -75,25 +66,30 @@ def run_rnav1_arrival(iface, routing_layer, params=None):
 
         if not selected_features:
             iface.messageBar().pushMessage(
-                "Error", 
-                "Please select at least one segment in the routing layer", 
+                "QPANSOPY",
+                "Please select at least one segment in the routing layer",
                 level=Qgis.Critical
             )
             return None
 
-        # Try to find arrival segment, but don't fail if attribute doesn't exist
-        arrival_features = []
-        try:
-            arrival_features = [
-                feat for feat in selected_features 
-                if feat.attribute('segment') == 'arrival'
-            ]
-        except Exception:
-            pass  # Attribute doesn't exist, use all selected
-        
+        arrival_features = [
+            feat for feat in selected_features
+            if feat.attribute('segment') == 'arrival'
+        ]
+
         if not arrival_features:
-            # Use all selected features if no 'arrival' attribute found
-            arrival_features = selected_features
+            iface.messageBar().pushMessage(
+                "QPANSOPY",
+                "No 'arrival' segment found in your selection",
+                level=Qgis.Critical
+            )
+            return None
+
+        iface.messageBar().pushMessage(
+            "QPANSOPY:",
+            "Executing RNAV 1 Arrival Segment",
+            level=Qgis.Info
+        )
 
         # Process the first valid feature
         start_point = None


### PR DESCRIPTION
# PR — Arrival segment filter + Missed Approach import fix (Issues #136, #137)

## Summary

- The Arrival tool now strictly requires the selected feature(s) to have `segment='arrival'`.
  Previously it silently fell back to using all selected features when no arrival attribute
  was found, allowing any segment type to be processed as an arrival.
- "Executing" message is moved after validation (same fix as #135).
- Routing layer resolution now uses the shared `_resolve_routing_layer` helper for consistency.
- Fixes Missed Approach crashing with `ModuleNotFoundError` — dockwidget was importing
  the old filename `PBN_LNAV_Missed_Approach`; corrected to `lnav_missed_approach`.

## Root Causes

**#136** — Lines 84–96 of `pbn_rnav1_arrival.py` had an explicit fallback:

```python
if not arrival_features:
    # Use all selected features if no 'arrival' attribute found
    arrival_features = selected_features
```

This meant a user could accidentally run the Arrival calculation on a `final` or `initial`
segment with no warning.

**#137** — The dockwidget imported the module by its old filename:

```python
from ...modules.pbn.PBN_LNAV_Missed_Approach import run_missed_approach  # ← wrong
```

The file was renamed to `lnav_missed_approach.py` in a previous refactor but the import
was never updated, causing an immediate `ModuleNotFoundError` on every Missed Approach run.

## Changes

| File | Change |
|---|---|
| `Q_Pansopy/modules/pbn/pbn_rnav1_arrival.py` | Remove `segment` fallback; Critical message when no `arrival` found; move "Executing" after validation; use `_resolve_routing_layer` |
| `Q_Pansopy/dockwidgets/pbn/qpansopy_lnav_dockwidget.py` | Fix import: `PBN_LNAV_Missed_Approach` → `lnav_missed_approach` |

## Test Plan

- [ ] Select a feature with `segment='final'`. Click Arrival. Confirm Critical message "No 'arrival' segment found in your selection" and no layer created.
- [ ] Select nothing. Click Arrival. Confirm "Please select at least one segment" message.
- [ ] Select a feature with `segment='arrival'`. Click Arrival. Confirm calculation runs correctly.
- [ ] Click Missed Approach with a valid `segment='missed'` feature selected. Confirm no `ModuleNotFoundError` and calculation runs.

## Related

Closes #136. Closes #137.
