### PR TITLE
Fix Missed Approach calculation (Issue #137 follow-up)

### DIFF
--- a/Q_Pansopy/modules/pbn/lnav_missed_approach.py
+++ b/Q_Pansopy/modules/pbn/lnav_missed_approach.py
@@ -43,7 +43,7 @@ from qgis.core import Qgis
 import math
 import os
 import datetime
-from ._lnav_common import _resolve_routing_layer, _create_area_layer
+from ._lnav_common import _resolve_routing_layer, _create_area_layer, _select_segment_features
 
 def run_missed_approach(iface_param, routing_layer, export_kml=False, output_dir=None):
     """
@@ -115,12 +115,8 @@ def run_missed_approach(iface_param, routing_layer, export_kml=False, output_dir
         if routing_layer is None:
             return None
 
-        # Select missed approach segments by expression
-        routing_layer.selectByExpression("segment='missed'")
-        selected_features = routing_layer.selectedFeatures()
-
-        if not selected_features:
-            iface.messageBar().pushMessage("No 'missed' segment found in routing layer", level=Qgis.Critical)
+        selected_features = _select_segment_features(iface, routing_layer, 'missed')
+        if selected_features is None:
             return None
 
         iface.messageBar().pushMessage("QPANSOPY:", "Executing LNAV Missed Approach (RNP APCH)", level=Qgis.Info)


### PR DESCRIPTION
# PR — Fix Missed Approach calculation (Issue #137 follow-up)

## Summary

Missed Approach calculation was silently blocked after PR #146 — clicking Calculate with
the Missed Approach radio button selected did nothing. The dockwidget returned early before
`run_missed_approach()` was ever called.
<img width="1920" height="1080" alt="{EF7352AA-2AEA-4F08-AAB6-6302EEA446CC}" src="https://github.com/user-attachments/assets/ad77149f-1ddc-4672-a530-11e62d4d21f3" />

## Root Cause

PR #146 added a pre-selection guard to the dockwidget `calculate()`:

```python
if routing_layer.selectedFeatureCount() == 0:
    self.log("Error: Please select at least one segment in the map before calculation")
    return
```

Every other module (initial, final, intermediate, arrival) uses `_select_segment_features()`
from `_lnav_common.py`, which operates on the user's pre-selected features — compatible with
this guard.

`lnav_missed_approach.py` used a different pattern: it called
`routing_layer.selectByExpression("segment='missed'")` inside the module to auto-select.
Because the guard fires before `run_missed_approach()` is ever reached, the module was
never executed when the user had nothing pre-selected.

## Changes

| File | Change |
|---|---|
| `Q_Pansopy/modules/pbn/lnav_missed_approach.py` | Replace `selectByExpression` auto-selection with `_select_segment_features(iface, routing_layer, 'missed')`; add it to the `_lnav_common` import |

## Test Plan

- [ ] Select Missed Approach with no pre-selection → confirm "Please select at least one segment" error appears (guard working).
- [ ] Select the `segment='missed'` feature in the routing layer, click Calculate → confirm "LNAV Missed" layer appears with correct geometry.
- [ ] Select a feature with `segment='final'`, click Missed Approach → confirm "No 'missed' segment found in your selection" Critical message.
- [ ] Confirm initial, final, intermediate and arrival still calculate correctly (no regression).