### PR TITLE
Active layer pre-selection for routing combo boxes (Issue #71)

### DIFF
--- a/Q_Pansopy/dockwidgets/conv/qpansopy_conv_initial_dockwidget.py
+++ b/Q_Pansopy/dockwidgets/conv/qpansopy_conv_initial_dockwidget.py
@@ -1,7 +1,7 @@
 ﻿from qgis.PyQt import QtGui, QtWidgets, uic
 from qgis.PyQt.QtCore import pyqtSignal, Qt
 from qgis.core import QgsMapLayerProxyModel
-from ...qt_compat import MLPM_LineLayer
+from ...qt_compat import MLPM_LineLayer, preseed_active_layer, Qgis_GeomType_Line
 import os
 
 FORM_CLASS, _ = uic.loadUiType(os.path.join(
@@ -17,7 +17,8 @@ class QPANSOPYConvInitialDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
 
         # Setup layer combobox
         self.routingLayerComboBox.setFilters(MLPM_LineLayer)
-        
+        preseed_active_layer(iface, self.routingLayerComboBox, Qgis_GeomType_Line)
+
         # Set default output folder
         self.outputFolderLineEdit.setText(self.get_desktop_path())
         

--- a/Q_Pansopy/dockwidgets/conv/qpansopy_ndb_dockwidget.py
+++ b/Q_Pansopy/dockwidgets/conv/qpansopy_ndb_dockwidget.py
@@ -1,7 +1,7 @@
 ﻿from qgis.PyQt import QtGui, QtWidgets, uic
 from qgis.PyQt.QtCore import pyqtSignal, Qt
 from qgis.core import QgsMapLayerProxyModel
-from ...qt_compat import MLPM_LineLayer
+from ...qt_compat import MLPM_LineLayer, preseed_active_layer, Qgis_GeomType_Line
 import os
 
 FORM_CLASS, _ = uic.loadUiType(os.path.join(
@@ -17,7 +17,8 @@ class QPANSOPYNDBDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
 
         # Setup layer combobox
         self.routingLayerComboBox.setFilters(MLPM_LineLayer)
-        
+        preseed_active_layer(iface, self.routingLayerComboBox, Qgis_GeomType_Line)
+
         # Set default output folder
         self.outputFolderLineEdit.setText(self.get_desktop_path())
         

--- a/Q_Pansopy/dockwidgets/conv/qpansopy_vor_dockwidget.py
+++ b/Q_Pansopy/dockwidgets/conv/qpansopy_vor_dockwidget.py
@@ -1,7 +1,7 @@
 ﻿from qgis.PyQt import QtGui, QtWidgets, uic
 from qgis.PyQt.QtCore import pyqtSignal, Qt
 from qgis.core import QgsMapLayerProxyModel
-from ...qt_compat import MLPM_LineLayer
+from ...qt_compat import MLPM_LineLayer, preseed_active_layer, Qgis_GeomType_Line
 import os
 
 FORM_CLASS, _ = uic.loadUiType(os.path.join(
@@ -17,7 +17,8 @@ class QPANSOPYVORDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
 
         # Setup layer combobox
         self.routingLayerComboBox.setFilters(MLPM_LineLayer)
-        
+        preseed_active_layer(iface, self.routingLayerComboBox, Qgis_GeomType_Line)
+
         # Set default output folder
         self.outputFolderLineEdit.setText(self.get_desktop_path())
         

--- a/Q_Pansopy/dockwidgets/departures/qpansopy_omnidirectional_dockwidget.py
+++ b/Q_Pansopy/dockwidgets/departures/qpansopy_omnidirectional_dockwidget.py
@@ -24,7 +24,7 @@ from qgis.PyQt import QtGui, QtWidgets, uic
 from qgis.PyQt.QtCore import pyqtSignal, Qt
 from qgis.core import QgsProject, QgsMapLayerProxyModel
 from qgis.core import Qgis
-from ...qt_compat import DOCK_FEATURES_DEFAULT, Qt_ALLOWED_DOCK_AREAS, MLPM_LineLayer
+from ...qt_compat import DOCK_FEATURES_DEFAULT, Qt_ALLOWED_DOCK_AREAS, MLPM_LineLayer, preseed_active_layer, Qgis_GeomType_Line
 
 
 # Use __file__ to get the current script path
@@ -57,6 +57,7 @@ class QPANSOPYOmnidirectionalDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         
         # Filter layers in comboboxes - Runway layer should be a line
         self.runwayLayerComboBox.setFilters(MLPM_LineLayer)
+        preseed_active_layer(iface, self.runwayLayerComboBox, Qgis_GeomType_Line)
         
         # Direction state: False = Start to End, True = End to Start
         self.is_reversed = False

--- a/Q_Pansopy/dockwidgets/departures/qpansopy_sid_initial_dockwidget.py
+++ b/Q_Pansopy/dockwidgets/departures/qpansopy_sid_initial_dockwidget.py
@@ -29,7 +29,7 @@ import datetime
 from qgis.PyQt import QtWidgets, uic
 from qgis.PyQt.QtCore import pyqtSignal, Qt, QMimeData
 from qgis.core import QgsMapLayerProxyModel, Qgis
-from ...qt_compat import DOCK_FEATURES_DEFAULT, Qt_ALLOWED_DOCK_AREAS, MLPM_LineLayer
+from ...qt_compat import DOCK_FEATURES_DEFAULT, Qt_ALLOWED_DOCK_AREAS, MLPM_LineLayer, preseed_active_layer, Qgis_GeomType_Line
 
 
 # Load UI file
@@ -78,6 +78,7 @@ class QPANSOPYSIDInitialDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         
         # Setup layer combobox
         self.runwayLayerComboBox.setFilters(MLPM_LineLayer)
+        preseed_active_layer(iface, self.runwayLayerComboBox, Qgis_GeomType_Line)
         
         # Connect signals
         self.calculateButton.clicked.connect(self.calculate)

--- a/Q_Pansopy/dockwidgets/ils/qpansopy_ils_dockwidget.py
+++ b/Q_Pansopy/dockwidgets/ils/qpansopy_ils_dockwidget.py
@@ -31,7 +31,7 @@ from qgis.PyQt.QtGui import QRegularExpressionValidator
 from qgis.core import QgsProject, QgsVectorLayer, QgsWkbTypes, QgsCoordinateReferenceSystem, QgsMapLayerProxyModel
 from qgis.core import Qgis
 from ...utils import format_parameters_table
-from ...qt_compat import DOCK_FEATURES_DEFAULT, FORM_FIELD_ROLE, Qt_ALLOWED_DOCK_AREAS, MLPM_PointLayer, MLPM_LineLayer
+from ...qt_compat import DOCK_FEATURES_DEFAULT, FORM_FIELD_ROLE, Qt_ALLOWED_DOCK_AREAS, MLPM_PointLayer, MLPM_LineLayer, preseed_active_layer, Qgis_GeomType_Line
 
 # Use __file__ to get the current script path
 FORM_CLASS, _ = uic.loadUiType(os.path.join(
@@ -72,6 +72,7 @@ class QPANSOPYILSDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
        # Filter layers in comboboxes
        self.pointLayerComboBox.setFilters(MLPM_PointLayer)
        self.runwayLayerComboBox.setFilters(MLPM_LineLayer)
+       preseed_active_layer(iface, self.runwayLayerComboBox, Qgis_GeomType_Line)
        
        # Reemplazar los spinboxes con QLineEdit y añadir selectores de unidades
        self.setup_lineedits()

--- a/Q_Pansopy/dockwidgets/ils/qpansopy_oas_ils_dockwidget.py
+++ b/Q_Pansopy/dockwidgets/ils/qpansopy_oas_ils_dockwidget.py
@@ -30,7 +30,7 @@ from qgis.PyQt.QtCore import pyqtSignal, QFileInfo, Qt, QRegularExpression, QMim
 from qgis.PyQt.QtGui import QRegularExpressionValidator
 from qgis.core import QgsProject, QgsVectorLayer, QgsWkbTypes, QgsCoordinateReferenceSystem, QgsMapLayerProxyModel
 from qgis.core import Qgis
-from ...qt_compat import DOCK_FEATURES_DEFAULT, Qt_ALLOWED_DOCK_AREAS, MLPM_PointLayer, MLPM_LineLayer
+from ...qt_compat import DOCK_FEATURES_DEFAULT, Qt_ALLOWED_DOCK_AREAS, MLPM_PointLayer, MLPM_LineLayer, preseed_active_layer, Qgis_GeomType_Line
 
 # Use __file__ to get the current script path
 FORM_CLASS, _ = uic.loadUiType(os.path.join(
@@ -81,6 +81,7 @@ class QPANSOPYOASILSDockWidgetBase(QtWidgets.QDockWidget, FORM_CLASS):
        # Filter layers in comboboxes
        self.pointLayerComboBox.setFilters(MLPM_PointLayer)
        self.runwayLayerComboBox.setFilters(MLPM_LineLayer)
+       preseed_active_layer(iface, self.runwayLayerComboBox, Qgis_GeomType_Line)
        
        # Reemplazar los spinboxes con QLineEdit y añadir selectores de unidades
        self.setup_lineedits()

--- a/Q_Pansopy/dockwidgets/pbn/qpansopy_gnss_waypoint_dockwidget.py
+++ b/Q_Pansopy/dockwidgets/pbn/qpansopy_gnss_waypoint_dockwidget.py
@@ -1,7 +1,7 @@
 ﻿from qgis.PyQt import QtGui, QtWidgets, uic
 from qgis.PyQt.QtCore import pyqtSignal, Qt
 from qgis.core import QgsMapLayerProxyModel
-from ...qt_compat import MLPM_PointLayer, MLPM_LineLayer
+from ...qt_compat import MLPM_PointLayer, MLPM_LineLayer, preseed_active_layer, Qgis_GeomType_Line
 import os
 
 FORM_CLASS, _ = uic.loadUiType(os.path.join(
@@ -19,6 +19,7 @@ class QPANSOPYGNSSWaypointDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         # Setup layer comboboxes
         self.waypointLayerComboBox.setFilters(MLPM_PointLayer)
         self.routingLayerComboBox.setFilters(MLPM_LineLayer)
+        preseed_active_layer(iface, self.routingLayerComboBox, Qgis_GeomType_Line)
         
         # Set default output folder
         self.outputFolderLineEdit.setText(self.get_desktop_path())

--- a/Q_Pansopy/dockwidgets/pbn/qpansopy_lnav_dockwidget.py
+++ b/Q_Pansopy/dockwidgets/pbn/qpansopy_lnav_dockwidget.py
@@ -1,7 +1,7 @@
 ﻿from qgis.PyQt import QtGui, QtWidgets, uic
 from qgis.PyQt.QtCore import pyqtSignal, Qt
 from qgis.core import QgsMapLayerProxyModel
-from ...qt_compat import MLPM_LineLayer
+from ...qt_compat import MLPM_LineLayer, preseed_active_layer, Qgis_GeomType_Line
 import os
 
 FORM_CLASS, _ = uic.loadUiType(os.path.join(
@@ -17,7 +17,8 @@ class QPANSOPYLNAVDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
 
         # Setup layer combobox
         self.routingLayerComboBox.setFilters(MLPM_LineLayer)
-        
+        preseed_active_layer(iface, self.routingLayerComboBox, Qgis_GeomType_Line)
+
         # Set default output folder
         self.outputFolderLineEdit.setText(self.get_desktop_path())
         

--- a/Q_Pansopy/dockwidgets/utilities/qpansopy_holding_dockwidget.py
+++ b/Q_Pansopy/dockwidgets/utilities/qpansopy_holding_dockwidget.py
@@ -2,7 +2,7 @@
 from qgis.PyQt import QtWidgets, uic
 from qgis.PyQt.QtCore import pyqtSignal, QMimeData
 from qgis.core import QgsMapLayerProxyModel, Qgis
-from ...qt_compat import MLPM_LineLayer
+from ...qt_compat import MLPM_LineLayer, preseed_active_layer, Qgis_GeomType_Line
 
 FORM_CLASS, _ = uic.loadUiType(os.path.join(
     os.path.dirname(__file__), '..', '..', 'ui', 'utilities', 'qpansopy_holding_dockwidget.ui'))
@@ -20,6 +20,7 @@ class QPANSOPYHoldingDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
 
         # Setup layer selector
         self.routingLayerComboBox.setFilters(MLPM_LineLayer)
+        preseed_active_layer(iface, self.routingLayerComboBox, Qgis_GeomType_Line)
 
         # Defaults
         self.altitudeUnitCombo.setCurrentText('ft')

--- a/Q_Pansopy/dockwidgets/utilities/qpansopy_vss_dockwidget.py
+++ b/Q_Pansopy/dockwidgets/utilities/qpansopy_vss_dockwidget.py
@@ -27,7 +27,7 @@ from qgis.PyQt.QtCore import pyqtSignal, QFileInfo, Qt, QRegularExpression, QMim
 from qgis.PyQt.QtGui import QRegularExpressionValidator
 from qgis.core import QgsProject, QgsVectorLayer, QgsWkbTypes, QgsCoordinateReferenceSystem, QgsMapLayerProxyModel
 from qgis.core import Qgis
-from ...qt_compat import DOCK_FEATURES_DEFAULT, FORM_FIELD_ROLE, Qt_ALLOWED_DOCK_AREAS, MLPM_PointLayer, MLPM_LineLayer
+from ...qt_compat import DOCK_FEATURES_DEFAULT, FORM_FIELD_ROLE, Qt_ALLOWED_DOCK_AREAS, MLPM_PointLayer, MLPM_LineLayer, preseed_active_layer, Qgis_GeomType_Line
 import json
 import datetime
 from ...utils import format_parameters_table
@@ -74,6 +74,7 @@ class QPANSOPYVSSDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         # Filter layers in comboboxes
         self.pointLayerComboBox.setFilters(MLPM_PointLayer)
         self.runwayLayerComboBox.setFilters(MLPM_LineLayer)
+        preseed_active_layer(iface, self.runwayLayerComboBox, Qgis_GeomType_Line)
         
         # Reemplazar los spinboxes con QLineEdit y añadir selectores de unidades
         self.setup_lineedits()

--- a/Q_Pansopy/dockwidgets/utilities/qpansopy_wind_spiral_dockwidget.py
+++ b/Q_Pansopy/dockwidgets/utilities/qpansopy_wind_spiral_dockwidget.py
@@ -26,7 +26,7 @@ from qgis.PyQt import QtGui, QtWidgets, uic, QtCore
 from qgis.PyQt.QtCore import pyqtSignal, QFileInfo, Qt, QRegularExpression, QMimeData
 from qgis.PyQt.QtGui import QRegularExpressionValidator
 from qgis.PyQt.QtWidgets import QMessageBox
-from ...qt_compat import Qt_AlignRight, Qt_AlignVCenter, Qt_AlignLeft, Qt_AlignTop, MLPM_PointLayer, MLPM_LineLayer
+from ...qt_compat import Qt_AlignRight, Qt_AlignVCenter, Qt_AlignLeft, Qt_AlignTop, MLPM_PointLayer, MLPM_LineLayer, preseed_active_layer, Qgis_GeomType_Line
 from qgis.core import QgsProject, QgsVectorLayer, QgsWkbTypes, QgsCoordinateReferenceSystem, QgsMapLayerProxyModel
 from qgis.gui import QgsMapLayerComboBox  # Importar QgsMapLayerComboBox
 from qgis.core import Qgis
@@ -75,6 +75,7 @@ class QPANSOPYWindSpiralDockWidgetBase(QtWidgets.QDockWidget, FORM_CLASS):
             self.pointLayerComboBox.setFilters(MLPM_PointLayer)
         if hasattr(self, 'referenceLayerComboBox'):
             self.referenceLayerComboBox.setFilters(MLPM_LineLayer)
+            preseed_active_layer(iface, self.referenceLayerComboBox, Qgis_GeomType_Line)
         
         # Set default output folder
         if hasattr(self, 'outputFolderLineEdit'):

--- a/Q_Pansopy/qt_compat.py
+++ b/Q_Pansopy/qt_compat.py
@@ -432,3 +432,24 @@ except AttributeError:
     QLayout_SetMaximumSize = QLayout.SetMaximumSize              # type: ignore[attr-defined]
     QLayout_SetMinAndMaxSize = QLayout.SetMinAndMaxSize          # type: ignore[attr-defined]
     QLayout_SetNoConstraint = QLayout.SetNoConstraint            # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# Active-layer pre-selection helper
+# ---------------------------------------------------------------------------
+
+def preseed_active_layer(iface, combo_box, geom_type) -> None:
+    """Pre-select iface.activeLayer() in combo_box if its geometry matches geom_type.
+
+    geom_type: one of Qgis_GeomType_Line, Qgis_GeomType_Point, Qgis_GeomType_Polygon.
+    All errors are silently swallowed so a missing active layer never breaks __init__.
+    """
+    try:
+        from qgis.core import QgsVectorLayer
+        active = iface.activeLayer()
+        if (active
+                and isinstance(active, QgsVectorLayer)
+                and active.geometryType() == geom_type):
+            combo_box.setLayer(active)
+    except Exception:
+        pass


### PR DESCRIPTION
# PR — Active layer pre-selection for routing combo boxes (Issue #71)

## Summary

When a dockwidget opens, if the currently active layer in QGIS has the correct geometry
type it is now automatically pre-selected in the layer combo box. All available layers
remain visible in the dropdown — the user can still change the selection freely.

## Behaviour

1. User sets a line layer as the active layer in QGIS (e.g. `routing`).
2. User opens any dockwidget (LNAV, NDB, VOR, SID, ILS, etc.).
3. The routing/runway/reference combo box is pre-filled with that layer.
4. If the active layer is not a line layer, the combo box defaults as before (alphabetical).
5. In all cases the dropdown is fully populated — no layers are hidden.

## Implementation

A single helper function `preseed_active_layer(iface, combo_box, geom_type)` was added to
`qt_compat.py` — already imported by every dockwidget — and called once after `setFilters()`
in each `__init__`. The function wraps everything in `try/except` so a missing or
incompatible active layer never breaks dockwidget initialisation.

```python
def preseed_active_layer(iface, combo_box, geom_type) -> None:
    try:
        from qgis.core import QgsVectorLayer
        active = iface.activeLayer()
        if active and isinstance(active, QgsVectorLayer) and active.geometryType() == geom_type:
            combo_box.setLayer(active)
    except Exception:
        pass
```

## Files Modified

| File | Change |
|---|---|
| `Q_Pansopy/qt_compat.py` | Add `preseed_active_layer()` helper |
| `Q_Pansopy/dockwidgets/pbn/qpansopy_lnav_dockwidget.py` | Pre-select `routingLayerComboBox` |
| `Q_Pansopy/dockwidgets/conv/qpansopy_conv_initial_dockwidget.py` | Pre-select `routingLayerComboBox` |
| `Q_Pansopy/dockwidgets/conv/qpansopy_ndb_dockwidget.py` | Pre-select `routingLayerComboBox` |
| `Q_Pansopy/dockwidgets/conv/qpansopy_vor_dockwidget.py` | Pre-select `routingLayerComboBox` |
| `Q_Pansopy/dockwidgets/pbn/qpansopy_gnss_waypoint_dockwidget.py` | Pre-select `routingLayerComboBox` |
| `Q_Pansopy/dockwidgets/utilities/qpansopy_holding_dockwidget.py` | Pre-select `routingLayerComboBox` |
| `Q_Pansopy/dockwidgets/departures/qpansopy_omnidirectional_dockwidget.py` | Pre-select `runwayLayerComboBox` |
| `Q_Pansopy/dockwidgets/departures/qpansopy_sid_initial_dockwidget.py` | Pre-select `runwayLayerComboBox` |
| `Q_Pansopy/dockwidgets/ils/qpansopy_ils_dockwidget.py` | Pre-select `runwayLayerComboBox` |
| `Q_Pansopy/dockwidgets/ils/qpansopy_oas_ils_dockwidget.py` | Pre-select `runwayLayerComboBox` |
| `Q_Pansopy/dockwidgets/utilities/qpansopy_vss_dockwidget.py` | Pre-select `runwayLayerComboBox` |
| `Q_Pansopy/dockwidgets/utilities/qpansopy_wind_spiral_dockwidget.py` | Pre-select `referenceLayerComboBox` |

## Test Plan

- [ ] Set `routing` (line layer) as active → open LNAV dockwidget → confirm `routing` is pre-selected.
- [ ] Set a point layer as active → open LNAV dockwidget → confirm combo defaults to first alphabetical line layer (no crash).
- [ ] Set active layer to `None` (no selection) → open any dockwidget → confirm no crash.
- [ ] Confirm all 12 dockwidgets open without error and show the full layer list in the dropdown.
- [ ] Confirm changing the combo after open still works normally.

## Related

Closes #71.
