### PR TITLE
Fix Dock Window Opens Too Small on First Open (Issue #156)

### DIFF
--- a/Q_Pansopy/qpansopy.py
+++ b/Q_Pansopy/qpansopy.py
@@ -21,6 +21,7 @@ from .qt_compat import (
     QFormLayout_AllNonFixedFieldsGrow,
     QTextEdit_WidgetWidth,
     QLayout_SetDefaultConstraint,
+    Qt_Vertical,
 )
 
 
@@ -526,6 +527,8 @@ class Qpansopy:
             self._wait_for_geometry_update()
             instance.show()
             instance.raise_()
+            # Expand dock to fill available area (issue #156)
+            self._expand_dock_to_fill(instance)
         else:
             # Toggle visibility of existing instance; hide siblings when showing
             if instance.isVisible():
@@ -540,6 +543,8 @@ class Qpansopy:
                 self._ensure_dock_anchor(name, instance)
                 instance.show()
                 instance.raise_()
+                # Expand dock to fill available area (issue #156)
+                self._expand_dock_to_fill(instance)
 
     def _ensure_resizable_log(self, dock_instance):
         """
@@ -957,6 +962,27 @@ class Qpansopy:
                 dock_instance.resize(300, 350)
             except Exception:
                 pass
+
+    def _expand_dock_to_fill(self, dock_instance):
+        """
+        Expand dock to fill available dock area height after show.
+
+        resizeDocks() redistributes existing dock area space without touching
+        the main window geometry, solving the "opens tiny" symptom while
+        keeping the issue #39 fix (no QGIS window resize) intact.
+        """
+        try:
+            screen = QGuiApplication.primaryScreen()
+            available_height = (
+                screen.availableGeometry().height() - 400
+                if screen else 600
+            )
+            available_height = max(available_height, 350)
+            self.iface.mainWindow().resizeDocks(
+                [dock_instance], [available_height], Qt_Vertical
+            )
+        except Exception:
+            pass
 
     def _wait_for_geometry_update(self):
         """

--- a/Q_Pansopy/qt_compat.py
+++ b/Q_Pansopy/qt_compat.py
@@ -435,6 +435,21 @@ except AttributeError:
 
 
 # ---------------------------------------------------------------------------
+# Qt5/Qt6 compatible Qt.Orientation enum values
+#
+# Qt5: Qt.Vertical / Qt.Horizontal  (unscoped)
+# Qt6: Qt.Orientation.Vertical  (scoped)
+# ---------------------------------------------------------------------------
+try:
+    _orient = Qt.Orientation
+    Qt_Vertical = _orient.Vertical
+    Qt_Horizontal = _orient.Horizontal
+except AttributeError:
+    Qt_Vertical = Qt.Vertical      # type: ignore[attr-defined]
+    Qt_Horizontal = Qt.Horizontal  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
 # Active-layer pre-selection helper
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
# PR — Fix Dock Window Opens Too Small on First Open (Issue #156)

## Summary

- Adds `Qt_Vertical` / `Qt_Horizontal` orientation constants to `qt_compat.py` (Qt5/Qt6 compatible).
- Adds `_expand_dock_to_fill()` to `Qpansopy` in `qpansopy.py`, which calls `QMainWindow.resizeDocks()` to grow the dock to fill available height without touching the main window geometry.
- Calls `_expand_dock_to_fill()` after `instance.show()` in both the first-open path and the re-open (toggle-show) path of `run_tool()`.

## Root cause

`_force_initial_small_size()` (added for issue #39) calls `dock_instance.resize(300, ~400)` before `addDockWidget()` to pre-seed Qt's size cache and prevent the QGIS main window from being resized on first open. After `instance.show()` there was no call to expand the dock, so Qt kept the cached 300×400 size for the lifetime of the session.

Detaching (floating) the dock worked because `QDockWidget::setFloating(true)` forces Qt to re-query `sizeHint()` without any prior size constraint.

## Implementation notes

`QMainWindow::resizeDocks(docks, sizes, orientation)` (Qt 5.6+, present in all QGIS 3.x builds) redistributes existing dock area space among the listed docks. It does **not** grow the main window, so issue #39 is not regressed. The call is wrapped in `try/except` so any environment that doesn't support it silently falls back to the pre-existing 300×400 size.

## Files Modified

| File | Change |
|---|---|
| `Q_Pansopy/qt_compat.py` | Add `Qt_Vertical` and `Qt_Horizontal` constants (Qt5 unscoped / Qt6 scoped enum compat) |
| `Q_Pansopy/qpansopy.py` | Import `Qt_Vertical`; add `_expand_dock_to_fill()` method; call after `instance.show()` in first-open and re-open paths |

## Test plan

- [x] 123 unit tests pass, 1 skipped — no regressions.
- [ ] Open any tool dock for the first time — verify it fills the available right-panel height instead of appearing at ~300×400 px.
- [ ] Toggle a dock closed and re-open it — verify it still fills available height on re-open.
- [ ] Open multiple docks in sequence — verify QGIS main window does not resize (issue #39 not regressed).
- [ ] Detach a dock — verify it still floats and sizes correctly.

## Related

Closes #156.
Preserves fix for #39.
