### PR TITLE
Add VOR/DME Tolerance Tool (Issue #86)

### DIFF
--- a/Q_Pansopy/dockwidgets/conv/qpansopy_vor_dme_tolerance_dockwidget.py
+++ b/Q_Pansopy/dockwidgets/conv/qpansopy_vor_dme_tolerance_dockwidget.py
@@ -1,0 +1,156 @@
+# -*- coding: utf-8 -*-
+import os
+from qgis.PyQt import QtWidgets, uic
+from qgis.PyQt.QtCore import pyqtSignal
+from qgis.PyQt.QtGui import QColor
+from qgis.gui import QgsRubberBand
+from qgis.core import (
+    QgsGeometry, QgsPoint, QgsLineString, QgsPolygon, QgsCircle,
+    QgsProject, QgsDistanceArea, QgsCoordinateTransform,
+)
+from ...qt_compat import (
+    MLPM_PointLayer,
+    preseed_active_layer, Qgis_GeomType_Point, Qgis_GeomType_Polygon,
+)
+
+FORM_CLASS, _ = uic.loadUiType(os.path.join(
+    os.path.dirname(__file__), '..', '..', 'ui', 'conv',
+    'qpansopy_vor_dme_tolerance_dockwidget.ui'))
+
+
+class QPANSOPYVORDMEToleranceDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
+    closingPlugin = pyqtSignal()
+
+    def __init__(self, iface):
+        super().__init__(iface.mainWindow())
+        self.setupUi(self)
+        self.iface = iface
+
+        self.pointLayerComboBox.setFilters(MLPM_PointLayer)
+        self.fixLayerComboBox.setFilters(MLPM_PointLayer)
+        preseed_active_layer(iface, self.pointLayerComboBox, Qgis_GeomType_Point)
+        preseed_active_layer(iface, self.fixLayerComboBox, Qgis_GeomType_Point)
+
+        self.calculateButton.clicked.connect(self.calculate)
+
+        # Live preview rubber band
+        self._preview_band = QgsRubberBand(iface.mapCanvas(), Qgis_GeomType_Polygon)
+        self._preview_band.setColor(QColor(0, 100, 255, 80))
+        self._preview_band.setStrokeColor(QColor(0, 100, 255, 200))
+        self._preview_band.setWidth(1)
+        self._connected_layers = []
+
+        self.pointLayerComboBox.layerChanged.connect(self._on_layer_changed)
+        self.fixLayerComboBox.layerChanged.connect(self._on_layer_changed)
+        self.rotateDoubleSpinBox.valueChanged.connect(self._update_preview)
+        self._on_layer_changed()
+
+    def closeEvent(self, event):
+        self._clear_preview()
+        self.closingPlugin.emit()
+        event.accept()
+
+    def _on_layer_changed(self):
+        for lyr in self._connected_layers:
+            try:
+                lyr.selectionChanged.disconnect(self._update_preview)
+            except Exception:
+                pass
+        self._connected_layers = []
+
+        seen = set()
+        for combo in [self.pointLayerComboBox, self.fixLayerComboBox]:
+            lyr = combo.currentLayer()
+            if lyr and id(lyr) not in seen:
+                lyr.selectionChanged.connect(self._update_preview)
+                self._connected_layers.append(lyr)
+                seen.add(id(lyr))
+
+        self._update_preview()
+
+    def _clear_preview(self):
+        if self._preview_band:
+            self._preview_band.reset(Qgis_GeomType_Polygon)
+
+    def _update_preview(self, *args):
+        self._clear_preview()
+
+        navid_layer = self.pointLayerComboBox.currentLayer()
+        fix_layer = self.fixLayerComboBox.currentLayer()
+        if not navid_layer or not fix_layer:
+            return
+
+        navid_sel = navid_layer.selectedFeatures()
+        fix_sel = fix_layer.selectedFeatures()
+        if not navid_sel or not fix_sel:
+            return
+
+        try:
+            map_crs = self.iface.mapCanvas().mapSettings().destinationCrs()
+            project = QgsProject.instance()
+
+            def to_map(feat, lyr):
+                g = feat.geometry()
+                g.transform(QgsCoordinateTransform(lyr.crs(), map_crs, project))
+                return g.asPoint()
+
+            navid_geom = to_map(navid_sel[0], navid_layer)
+            fix_geom = to_map(fix_sel[0], fix_layer)
+
+            rotate = self.rotateDoubleSpinBox.value()
+            azimuth = navid_geom.azimuth(fix_geom)
+            length0 = navid_geom.distance(fix_geom)
+            if length0 == 0:
+                return
+
+            da = QgsDistanceArea()
+            da.setSourceCrs(map_crs, project.transformContext())
+            da.setEllipsoid(project.ellipsoid())
+            length0_m = da.measureLine(navid_geom, fix_geom)
+
+            dme_tol_m = 0.25 * 1852 + 0.0125 * length0_m
+            dme_tolerance = (dme_tol_m / length0_m) * length0 if length0_m > 0 else dme_tol_m
+
+            pt1 = QgsPoint(navid_geom)
+            proj2 = navid_geom.project(length0 * 5, azimuth + rotate)
+            proj3 = navid_geom.project(length0 * 5, azimuth - rotate)
+            sector = QgsGeometry(QgsPolygon(QgsLineString([pt1, QgsPoint(proj2), QgsPoint(proj3)])))
+
+            dme_circle = QgsGeometry(
+                QgsCircle(QgsPoint(navid_geom), length0).toCircularString()
+            ).buffer(dme_tolerance, 360)
+
+            tolerance_area = sector.intersection(dme_circle)
+            if tolerance_area and not tolerance_area.isEmpty():
+                self._preview_band.setToGeometry(tolerance_area, None)
+        except Exception:
+            pass
+
+    def log(self, message):
+        self.logTextEdit.append(message)
+        self.logTextEdit.ensureCursorVisible()
+
+    def calculate(self):
+        navid_layer = self.pointLayerComboBox.currentLayer()
+        fix_layer = self.fixLayerComboBox.currentLayer()
+
+        if not navid_layer:
+            self.log("Error: Please select a NAVID point layer")
+            return
+        if not fix_layer:
+            self.log("Error: Please select a Fix point layer")
+            return
+
+        params = {'rotate': self.rotateDoubleSpinBox.value()}
+
+        try:
+            self.log("Calculating VOR/DME Tolerance...")
+            from ...modules.conv.vor_dme_tolerance import run_vor_dme_tolerance
+            result = run_vor_dme_tolerance(self.iface, navid_layer, fix_layer, params)
+            if result:
+                self._clear_preview()
+                self.log("VOR/DME Tolerance calculation completed successfully")
+        except Exception as e:
+            self.log(f"Error during calculation: {e}")
+            import traceback
+            self.log(traceback.format_exc())

--- a/Q_Pansopy/icons/vor_dme_tolerance.svg
+++ b/Q_Pansopy/icons/vor_dme_tolerance.svg
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created following QPANSOPY icon style -->
+<svg
+   width="48"
+   height="48"
+   viewBox="0 0 48 48"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
+   sodipodi:docname="vor_dme_tolerance.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.0"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="px"
+     showgrid="true"
+     inkscape:current-layer="layer1">
+  </sodipodi:namedview>
+  <defs id="defs1" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <!-- Filled tolerance zone: pie slice inside sector up to DME arc (blue = output layer color) -->
+    <path
+       id="tolerance-fill"
+       style="fill:#4488ff;fill-opacity:0.35;stroke:none"
+       d="M 24,4 L 14,24 A 22,22 0 0 1 34,24 Z" />
+    <!-- VOR sector outline: two arms from station (apex up) -->
+    <path
+       id="sector"
+       style="opacity:1;fill:none;stroke:#000000;stroke-width:1.2;stroke-opacity:1"
+       d="M 4,44 L 24,4 L 44,44" />
+    <!-- DME distance arc at nominal fix range -->
+    <path
+       id="dme-arc"
+       style="opacity:1;fill:none;stroke:#000000;stroke-width:1.5;stroke-opacity:1"
+       d="M 14,24 A 22,22 0 0 1 34,24" />
+    <!-- Station dot at apex -->
+    <circle
+       id="station"
+       style="fill:#000000;stroke:none"
+       cx="24"
+       cy="4"
+       r="1.8" />
+    <!-- Tool label -->
+    <text
+       xml:space="preserve"
+       style="font-weight:bold;font-stretch:condensed;font-size:14.5px;font-family:arial;-inkscape-font-specification:'arial Bold Condensed';text-align:center;text-anchor:middle;writing-mode:lr-tb;direction:ltr;opacity:1;fill:#000000;stroke:#000000;stroke-width:0.25;stroke-opacity:1"
+       x="24"
+       y="40"
+       id="text1">DME</text>
+  </g>
+</svg>

--- a/Q_Pansopy/modules/conv/vor_dme_tolerance.py
+++ b/Q_Pansopy/modules/conv/vor_dme_tolerance.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+from qgis.core import (
+    QgsProject, QgsVectorLayer, QgsFeature, QgsGeometry,
+    QgsPoint, QgsLineString, QgsPolygon, QgsCircle, QgsField, Qgis,
+    QgsDistanceArea, QgsCoordinateTransform,
+)
+from qgis.PyQt.QtCore import QVariant
+from qgis.PyQt.QtGui import QColor
+from ...utils import get_selected_feature
+
+
+def _geom_to_map_crs(feature, layer, map_crs, project):
+    """Return feature point geometry transformed to the map CRS."""
+    g = feature.geometry()
+    g.transform(QgsCoordinateTransform(layer.crs(), map_crs, project))
+    return g.asPoint()
+
+
+def run_vor_dme_tolerance(iface, navid_layer, fix_layer, params=None):
+    """
+    Calculate VOR/DME fix tolerance area.
+
+    Intersects the VOR angular sector (±rotate° off nominal track) with the
+    DME tolerance ring (0.25 NM fixed + 1.25 % of distance), producing the
+    fix tolerance area per ICAO Doc 8168.
+
+    :param iface: QGIS interface
+    :param navid_layer: Point layer containing the VOR/DME station (NAVID)
+    :param fix_layer: Point layer containing the fix/threshold point
+    :param params: Optional dict; supports key 'rotate' (half-angle in degrees, default 5.2)
+    :return: True on success, False on failure
+    """
+    if params is None:
+        params = {}
+    rotate = float(params.get('rotate', 5.2))
+
+    map_crs = iface.mapCanvas().mapSettings().destinationCrs()
+    map_srid = map_crs.authid()
+    project = QgsProject.instance()
+
+    def show_error(msg):
+        iface.messageBar().pushMessage("QPANSOPY:", msg, level=Qgis.Critical)
+
+    navid_feature = get_selected_feature(navid_layer, show_error)
+    if navid_feature is None:
+        return False
+
+    fix_feature = get_selected_feature(fix_layer, show_error)
+    if fix_feature is None:
+        return False
+
+    # Transform both points to map CRS so calculations and output layer match
+    navid_geom = _geom_to_map_crs(navid_feature, navid_layer, map_crs, project)
+    fix_geom = _geom_to_map_crs(fix_feature, fix_layer, map_crs, project)
+
+    # Azimuth and map-unit distance (used for sector geometry)
+    azimuth = navid_geom.azimuth(fix_geom)
+    length0 = navid_geom.distance(fix_geom)  # map units
+
+    # Ellipsoidal distance in metres (for tolerance formula and Distance_NM)
+    da = QgsDistanceArea()
+    da.setSourceCrs(map_crs, project.transformContext())
+    da.setEllipsoid(project.ellipsoid())
+    length0_m = da.measureLine(navid_geom, fix_geom)
+
+    distance_nm = round(length0_m / 1852, 3)
+
+    # DME tolerance in metres → convert to map units via the ratio
+    dme_tol_m = 0.25 * 1852 + 0.0125 * length0_m
+    dme_tolerance = (dme_tol_m / length0_m) * length0 if length0_m > 0 else dme_tol_m
+
+    # VOR sector triangle: apex at NAVID, ±rotate° for 5× the nominal distance
+    pt1 = QgsPoint(navid_geom)
+    proj2 = navid_geom.project(length0 * 5, azimuth + rotate)
+    proj3 = navid_geom.project(length0 * 5, azimuth - rotate)
+    pt2 = QgsPoint(proj2)
+    pt3 = QgsPoint(proj3)
+    sector = QgsGeometry(QgsPolygon(QgsLineString([pt1, pt2, pt3])))
+
+    # DME tolerance ring: circle of radius = distance, buffered by tolerance
+    dme_circle = QgsGeometry(
+        QgsCircle(QgsPoint(navid_geom), length0).toCircularString()
+    ).buffer(dme_tolerance, 360)
+
+    tolerance_area = sector.intersection(dme_circle)
+
+    # Build result layer
+    v_layer = QgsVectorLayer(f"Polygon?crs={map_srid}", "VORDME_tolerance", "memory")
+    pr = v_layer.dataProvider()
+    pr.addAttributes([
+        QgsField('Symbol', QVariant.String),
+        QgsField('Distance_NM', QVariant.Double),
+    ])
+    v_layer.updateFields()
+
+    seg = QgsFeature()
+    seg.setGeometry(tolerance_area)
+    seg.setAttributes(['VOR/DME Tolerance', distance_nm])
+    pr.addFeatures([seg])
+    v_layer.updateExtents()
+
+    v_layer.renderer().symbol().setOpacity(0.3)
+    v_layer.renderer().symbol().setColor(QColor('blue'))
+    v_layer.triggerRepaint()
+
+    QgsProject.instance().addMapLayer(v_layer)
+    iface.messageBar().pushMessage(
+        "QPANSOPY:", "VOR/DME Tolerance calculated successfully", level=Qgis.Success
+    )
+    return True

--- a/Q_Pansopy/qpansopy.py
+++ b/Q_Pansopy/qpansopy.py
@@ -44,6 +44,7 @@ try:
     from .dockwidgets.conv.qpansopy_vor_dockwidget import QPANSOPYVORDockWidget
     from .dockwidgets.conv.qpansopy_ndb_dockwidget import QPANSOPYNDBDockWidget
     from .dockwidgets.conv.qpansopy_conv_initial_dockwidget import QPANSOPYConvInitialDockWidget
+    from .dockwidgets.conv.qpansopy_vor_dme_tolerance_dockwidget import QPANSOPYVORDMEToleranceDockWidget
     from .dockwidgets.departures.qpansopy_sid_initial_dockwidget import QPANSOPYSIDInitialDockWidget
     from .dockwidgets.departures.qpansopy_omnidirectional_dockwidget import QPANSOPYOmnidirectionalDockWidget
     from .settings_dialog import SettingsDialog  # Import settings dialog
@@ -237,6 +238,14 @@ class Qpansopy:
                     "TOOLTIP": "CONV Initial Approach Straight Areas Tool",
                     "ICON": os.path.join(self.icons_dir, 'conv_corridor.svg'),
                     "DOCK_WIDGET": QPANSOPYConvInitialDockWidget,
+                    "GUI_INSTANCE": None
+                },
+                "VOR_DME_TOL": {
+                    "TITLE": "VOR/DME Tol",
+                    "TOOLBAR": "CONV",
+                    "TOOLTIP": "VOR/DME Tolerance Tool — sector × DME ring intersection",
+                    "ICON": os.path.join(self.icons_dir, 'vor_dme_tolerance.svg'),
+                    "DOCK_WIDGET": QPANSOPYVORDMEToleranceDockWidget,
                     "GUI_INSTANCE": None
                 },
                 "ObjectSelection": {

--- a/Q_Pansopy/ui/conv/qpansopy_vor_dme_tolerance_dockwidget.ui
+++ b/Q_Pansopy/ui/conv/qpansopy_vor_dme_tolerance_dockwidget.ui
@@ -1,0 +1,230 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QPANSOPYVORDMEToleranceDockWidget</class>
+ <widget class="QDockWidget" name="QPANSOPYVORDMEToleranceDockWidget">
+  <property name="minimumSize">
+   <size>
+    <width>250</width>
+    <height>200</height>
+   </size>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>16777215</width>
+    <height>16777215</height>
+   </size>
+  </property>
+  <widget class="QWidget" name="dockWidgetContents">
+   <layout class="QVBoxLayout" name="verticalLayout">
+    <property name="spacing">
+     <number>1</number>
+    </property>
+    <property name="margin">
+     <number>2</number>
+    </property>
+    <item>
+     <widget class="QGroupBox" name="inputGroup">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="title">
+       <string>Input Layers</string>
+      </property>
+      <layout class="QVBoxLayout" name="inputLayout">
+       <property name="spacing">
+        <number>2</number>
+       </property>
+       <property name="margin">
+        <number>4</number>
+       </property>
+       <item>
+        <widget class="QLabel" name="pointLayerLabel">
+         <property name="text">
+          <string>DME Point Layer</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QgsMapLayerComboBox" name="pointLayerComboBox">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="fixLayerLabel">
+         <property name="text">
+          <string>Fix Point Layer</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QgsMapLayerComboBox" name="fixLayerComboBox">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="fixLayerHintLabel">
+         <property name="text">
+          <string>⚑ Output polygon is drawn at the Fix point location</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+         <property name="styleSheet">
+          <string>color: #888888; font-size: 10px;</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </item>
+    <item>
+     <widget class="QGroupBox" name="paramsGroup">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="title">
+       <string>Parameters</string>
+      </property>
+      <layout class="QFormLayout" name="paramsLayout">
+       <property name="spacing">
+        <number>2</number>
+       </property>
+       <property name="margin">
+        <number>4</number>
+       </property>
+       <item row="0" column="0">
+        <widget class="QLabel" name="rotateLabel">
+         <property name="text">
+          <string>Sector Angle (°)</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QDoubleSpinBox" name="rotateDoubleSpinBox">
+         <property name="minimum">
+          <double>1.000000000000000</double>
+         </property>
+         <property name="maximum">
+          <double>15.000000000000000</double>
+         </property>
+         <property name="singleStep">
+          <double>0.100000000000000</double>
+         </property>
+         <property name="value">
+          <double>5.200000000000000</double>
+         </property>
+         <property name="decimals">
+          <number>1</number>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </item>
+    <item>
+     <widget class="QGroupBox" name="actionGroup">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="title">
+       <string>Actions</string>
+      </property>
+      <layout class="QVBoxLayout" name="actionLayout">
+       <property name="spacing">
+        <number>2</number>
+       </property>
+       <property name="margin">
+        <number>4</number>
+       </property>
+       <item>
+        <widget class="QPushButton" name="calculateButton">
+         <property name="text">
+          <string>Calculate VOR/DME Tolerance</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </item>
+    <item>
+     <widget class="QGroupBox" name="logGroup">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="title">
+       <string>Log</string>
+      </property>
+      <layout class="QVBoxLayout" name="logLayout">
+       <property name="spacing">
+        <number>2</number>
+       </property>
+       <property name="margin">
+        <number>4</number>
+       </property>
+       <item>
+        <widget class="QTextEdit" name="logTextEdit">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>1</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumHeight">
+          <number>100</number>
+         </property>
+         <property name="readOnly">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </item>
+    <item>
+     <spacer name="verticalSpacer">
+      <property name="orientation">
+       <enum>Qt::Vertical</enum>
+      </property>
+      <property name="sizeHint" stdset="0">
+       <size>
+        <width>20</width>
+        <height>20</height>
+       </size>
+      </property>
+     </spacer>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsMapLayerComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgsmaplayercombobox.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
# PR — Add VOR/DME Tolerance Tool (Issue #86)

## Summary

- Integrates the VOR/DME tolerance script into QPANSOPY as a proper dockwidget under the **CONV** toolbar, following the 4-artifact pattern.
- Replaces the original routing line input with two point layers (NAVID + Fix), so the distance and azimuth are computed internally from the two selected points.
- Adds a live canvas preview (rubber band) that renders the tolerance polygon as soon as both features are selected — no need to click Calculate.
- Fixes a CRS unit-mismatch bug that placed the output in the wrong location when layers were in a geographic CRS (WGS84).
- Stores the fix distance in nautical miles in the output layer's attribute table.
- Documents the module-addition pattern in `CLAUDE.md` for future sessions.
<img width="1416" height="889" alt="{CC9FC0B1-50C0-475D-A06B-05C58B74DC3D}" src="https://github.com/user-attachments/assets/5abee62f-9c08-4a8d-9de9-03a0f4e68b01" />
<img width="39" height="39" alt="{EE9DCFA6-A49B-459A-BBA9-6FE98BADC244}" src="https://github.com/user-attachments/assets/f1fa179c-5c1a-4b24-9662-69a3b57ca59b" />
<img width="139" height="46" alt="{CFFFFA1C-9041-40D7-B49D-4D8AC142F3E6}" src="https://github.com/user-attachments/assets/b9f01b44-81ee-4ca2-aad2-1cff4570729e" />

## Root cause

The calculation logic existed as a standalone QGIS Python console script. It had no UI wrapper, no integration with the plugin toolbar, and referenced `iface` as a global variable. The script also assumed the input layers were in a projected (metre-based) CRS: the DME tolerance formula `0.25 × 1852 + 0.0125 × distance` produces a value in metres that was passed directly to `buffer()`. When layers were in WGS84 (degrees), that value was interpreted as degrees, creating a tolerance ring the size of the planet and placing the output polygon in the wrong location.

## Implementation notes

### Two-point input model
The original script derived distance and azimuth from a routing polyline (runway). The new model accepts two point layers — NAVID (VOR/DME station) and Fix (the approach fix) — and computes both values internally:

```python
azimuth = navid_geom.azimuth(fix_geom)   # direction NAVID → Fix (degrees)
length0 = navid_geom.distance(fix_geom)  # map-unit distance
```

### CRS fix
`QgsDistanceArea` measures the ellipsoidal distance in metres regardless of the project CRS. Feature geometries are transformed to the map CRS before any calculation, so the output layer coordinates always match:

```python
da = QgsDistanceArea()
da.setSourceCrs(map_crs, project.transformContext())
da.setEllipsoid(project.ellipsoid())
length0_m = da.measureLine(navid_geom, fix_geom)           # metres

dme_tol_m   = 0.25 * 1852 + 0.0125 * length0_m            # metres
dme_tolerance = (dme_tol_m / length0_m) * length0         # → map units
```

### Live preview
`QgsRubberBand` draws the tolerance polygon on the canvas in real time. The dockwidget connects to `QgsVectorLayer.selectionChanged` on both combos and recomputes on every selection or angle change. The rubber band is cleared when Calculate is clicked (replaced by the permanent layer) and when the dock is closed.

### Geometry
The intersection of two areas per ICAO Doc 8168:
1. **VOR sector** — triangle with apex at NAVID, arms extending 5× the fix distance at ±`rotate`° off the NAVID→Fix azimuth.
2. **DME tolerance ring** — annulus around the nominal DME arc, tolerance radius `0.25 NM + 1.25 % of distance`, built with `QgsCircle.toCircularString().buffer()`.

`get_selected_feature()` from `Q_Pansopy/utils.py` handles 0/1/many selection logic.

## Files Added

| File | Description |
|---|---|
| `Q_Pansopy/modules/conv/vor_dme_tolerance.py` | Calculation function `run_vor_dme_tolerance(iface, navid_layer, fix_layer, params)` |
| `Q_Pansopy/ui/conv/qpansopy_vor_dme_tolerance_dockwidget.ui` | Qt Designer UI — two point-layer combos, sector angle spinbox, log |
| `Q_Pansopy/dockwidgets/conv/qpansopy_vor_dme_tolerance_dockwidget.py` | Dockwidget class with live rubber-band preview |
| `Q_Pansopy/icons/vor_dme_tolerance.svg` | Aviation-themed toolbar icon (sector + DME arc) |
| `docs/plan-86.md` | Implementation plan |
| `docs/vor-dme-base-script.md` | Original console script (reference, for output comparison) |

## Files Modified

| File | Change |
|---|---|
| `Q_Pansopy/qpansopy.py` | Import `QPANSOPYVORDMEToleranceDockWidget`; add `"VOR_DME_TOL"` entry in `self.modules` under CONV toolbar |
| `CLAUDE.md` | New section "Adding a New QGIS Module (Dockwidget Pattern)" documents the 4-artifact recipe |

## Test plan

- [x] 123 unit tests pass, 1 skipped — no regressions (`pytest tests/ -q`).
- [x] Flake8: 0 findings on new files.
- [x] Bandit: 0 Medium/High on new module.
- [ ] CONV toolbar shows new "VOR/DME Tol" button after plugin reload.
- [ ] Select a NAVID feature and a Fix feature — rubber-band preview appears on the canvas near the Fix before clicking Calculate.
- [ ] Changing the Sector Angle spinbox updates the preview in real time.
- [ ] Click Calculate — "VORDME_tolerance" polygon layer appears in blue (~30 % opacity) at the Fix location; attribute table contains `Symbol` and `Distance_NM`.
- [ ] Layers in WGS84 (geographic CRS) — output polygon appears at the correct Fix location, not displaced.
- [ ] Close dock via X and re-open — rubber band is cleared, fresh dock opens.

## Related

Closes #86.
