### PR TITLE
Add NDB/DME Tolerance Tool (Issue #161)

### DIFF
--- a/Q_Pansopy/dockwidgets/conv/qpansopy_ndb_dme_tolerance_dockwidget.py
+++ b/Q_Pansopy/dockwidgets/conv/qpansopy_ndb_dme_tolerance_dockwidget.py
@@ -1,0 +1,156 @@
+# -*- coding: utf-8 -*-
+import os
+from qgis.PyQt import QtWidgets, uic
+from qgis.PyQt.QtCore import pyqtSignal
+from qgis.PyQt.QtGui import QColor
+from qgis.gui import QgsRubberBand
+from qgis.core import (
+    QgsGeometry, QgsPoint, QgsLineString, QgsPolygon, QgsCircle,
+    QgsProject, QgsDistanceArea, QgsCoordinateTransform,
+)
+from ...qt_compat import (
+    MLPM_PointLayer,
+    preseed_active_layer, Qgis_GeomType_Point, Qgis_GeomType_Polygon,
+)
+
+FORM_CLASS, _ = uic.loadUiType(os.path.join(
+    os.path.dirname(__file__), '..', '..', 'ui', 'conv',
+    'qpansopy_ndb_dme_tolerance_dockwidget.ui'))
+
+
+class QPANSOPYNDBDMEToleranceDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
+    closingPlugin = pyqtSignal()
+
+    def __init__(self, iface):
+        super().__init__(iface.mainWindow())
+        self.setupUi(self)
+        self.iface = iface
+
+        self.pointLayerComboBox.setFilters(MLPM_PointLayer)
+        self.fixLayerComboBox.setFilters(MLPM_PointLayer)
+        preseed_active_layer(iface, self.pointLayerComboBox, Qgis_GeomType_Point)
+        preseed_active_layer(iface, self.fixLayerComboBox, Qgis_GeomType_Point)
+
+        self.calculateButton.clicked.connect(self.calculate)
+
+        # Live preview rubber band
+        self._preview_band = QgsRubberBand(iface.mapCanvas(), Qgis_GeomType_Polygon)
+        self._preview_band.setColor(QColor(0, 100, 255, 80))
+        self._preview_band.setStrokeColor(QColor(0, 100, 255, 200))
+        self._preview_band.setWidth(1)
+        self._connected_layers = []
+
+        self.pointLayerComboBox.layerChanged.connect(self._on_layer_changed)
+        self.fixLayerComboBox.layerChanged.connect(self._on_layer_changed)
+        self.rotateDoubleSpinBox.valueChanged.connect(self._update_preview)
+        self._on_layer_changed()
+
+    def closeEvent(self, event):
+        self._clear_preview()
+        self.closingPlugin.emit()
+        event.accept()
+
+    def _on_layer_changed(self):
+        for lyr in self._connected_layers:
+            try:
+                lyr.selectionChanged.disconnect(self._update_preview)
+            except Exception:
+                pass
+        self._connected_layers = []
+
+        seen = set()
+        for combo in [self.pointLayerComboBox, self.fixLayerComboBox]:
+            lyr = combo.currentLayer()
+            if lyr and id(lyr) not in seen:
+                lyr.selectionChanged.connect(self._update_preview)
+                self._connected_layers.append(lyr)
+                seen.add(id(lyr))
+
+        self._update_preview()
+
+    def _clear_preview(self):
+        if self._preview_band:
+            self._preview_band.reset(Qgis_GeomType_Polygon)
+
+    def _update_preview(self, *args):
+        self._clear_preview()
+
+        navid_layer = self.pointLayerComboBox.currentLayer()
+        fix_layer = self.fixLayerComboBox.currentLayer()
+        if not navid_layer or not fix_layer:
+            return
+
+        navid_sel = navid_layer.selectedFeatures()
+        fix_sel = fix_layer.selectedFeatures()
+        if not navid_sel or not fix_sel:
+            return
+
+        try:
+            map_crs = self.iface.mapCanvas().mapSettings().destinationCrs()
+            project = QgsProject.instance()
+
+            def to_map(feat, lyr):
+                g = feat.geometry()
+                g.transform(QgsCoordinateTransform(lyr.crs(), map_crs, project))
+                return g.asPoint()
+
+            navid_geom = to_map(navid_sel[0], navid_layer)
+            fix_geom = to_map(fix_sel[0], fix_layer)
+
+            rotate = self.rotateDoubleSpinBox.value()
+            azimuth = navid_geom.azimuth(fix_geom)
+            length0 = navid_geom.distance(fix_geom)
+            if length0 == 0:
+                return
+
+            da = QgsDistanceArea()
+            da.setSourceCrs(map_crs, project.transformContext())
+            da.setEllipsoid(project.ellipsoid())
+            length0_m = da.measureLine(navid_geom, fix_geom)
+
+            dme_tol_m = 0.25 * 1852 + 0.0125 * length0_m
+            dme_tolerance = (dme_tol_m / length0_m) * length0 if length0_m > 0 else dme_tol_m
+
+            pt1 = QgsPoint(navid_geom)
+            proj2 = navid_geom.project(length0 * 5, azimuth + rotate)
+            proj3 = navid_geom.project(length0 * 5, azimuth - rotate)
+            sector = QgsGeometry(QgsPolygon(QgsLineString([pt1, QgsPoint(proj2), QgsPoint(proj3)])))
+
+            dme_circle = QgsGeometry(
+                QgsCircle(QgsPoint(navid_geom), length0).toCircularString()
+            ).buffer(dme_tolerance, 360)
+
+            tolerance_area = sector.intersection(dme_circle)
+            if tolerance_area and not tolerance_area.isEmpty():
+                self._preview_band.setToGeometry(tolerance_area, None)
+        except Exception:
+            pass
+
+    def log(self, message):
+        self.logTextEdit.append(message)
+        self.logTextEdit.ensureCursorVisible()
+
+    def calculate(self):
+        navid_layer = self.pointLayerComboBox.currentLayer()
+        fix_layer = self.fixLayerComboBox.currentLayer()
+
+        if not navid_layer:
+            self.log("Error: Please select a NAVID point layer")
+            return
+        if not fix_layer:
+            self.log("Error: Please select a Fix point layer")
+            return
+
+        params = {'rotate': self.rotateDoubleSpinBox.value()}
+
+        try:
+            self.log("Calculating NDB/DME Tolerance...")
+            from ...modules.conv.ndb_dme_tolerance import run_ndb_dme_tolerance
+            result = run_ndb_dme_tolerance(self.iface, navid_layer, fix_layer, params)
+            if result:
+                self._clear_preview()
+                self.log("NDB/DME Tolerance calculation completed successfully")
+        except Exception as e:
+            self.log(f"Error during calculation: {e}")
+            import traceback
+            self.log(traceback.format_exc())

--- a/Q_Pansopy/icons/ndb_dme_tolerance.svg
+++ b/Q_Pansopy/icons/ndb_dme_tolerance.svg
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created following QPANSOPY icon style -->
+<svg
+   width="48"
+   height="48"
+   viewBox="0 0 48 48"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
+   sodipodi:docname="ndb_dme_tolerance.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.0"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="px"
+     showgrid="true"
+     inkscape:current-layer="layer1">
+  </sodipodi:namedview>
+  <defs id="defs1" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <!-- Filled tolerance zone (blue = output layer colour) -->
+    <path
+       id="tolerance-fill"
+       style="fill:#4488ff;fill-opacity:0.35;stroke:none"
+       d="M 24,4 L 12,24 A 22,22 0 0 1 36,24 Z" />
+    <!-- NDB sector outline: wider arms (6.9°) from station apex -->
+    <path
+       id="sector"
+       style="opacity:1;fill:none;stroke:#000000;stroke-width:1.2;stroke-opacity:1"
+       d="M 2,44 L 24,4 L 46,44" />
+    <!-- DME distance arc at nominal fix range -->
+    <path
+       id="dme-arc"
+       style="opacity:1;fill:none;stroke:#000000;stroke-width:1.5;stroke-opacity:1"
+       d="M 12,24 A 22,22 0 0 1 36,24" />
+    <!-- NDB station symbol at apex: outer ring + centre dot -->
+    <circle
+       id="ndb-ring"
+       style="fill:none;stroke:#000000;stroke-width:1.2"
+       cx="24"
+       cy="4"
+       r="3.2" />
+    <circle
+       id="ndb-dot"
+       style="fill:#000000;stroke:none"
+       cx="24"
+       cy="4"
+       r="1.4" />
+    <!-- Tool label -->
+    <text
+       xml:space="preserve"
+       style="font-weight:bold;font-stretch:condensed;font-size:14.5px;font-family:arial;-inkscape-font-specification:'arial Bold Condensed';text-align:center;text-anchor:middle;writing-mode:lr-tb;direction:ltr;opacity:1;fill:#000000;stroke:#000000;stroke-width:0.25;stroke-opacity:1"
+       x="24"
+       y="40"
+       id="text1">NDB</text>
+  </g>
+</svg>

--- a/Q_Pansopy/modules/conv/ndb_dme_tolerance.py
+++ b/Q_Pansopy/modules/conv/ndb_dme_tolerance.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+from qgis.core import (
+    QgsProject, QgsVectorLayer, QgsFeature, QgsGeometry,
+    QgsPoint, QgsLineString, QgsPolygon, QgsCircle, QgsField, Qgis,
+    QgsDistanceArea, QgsCoordinateTransform,
+)
+from qgis.PyQt.QtCore import QVariant
+from qgis.PyQt.QtGui import QColor
+from ...utils import get_selected_feature
+
+
+def _geom_to_map_crs(feature, layer, map_crs, project):
+    """Return feature point geometry transformed to the map CRS."""
+    g = feature.geometry()
+    g.transform(QgsCoordinateTransform(layer.crs(), map_crs, project))
+    return g.asPoint()
+
+
+def run_ndb_dme_tolerance(iface, navid_layer, fix_layer, params=None):
+    """
+    Calculate NDB/DME fix tolerance area.
+
+    Intersects the NDB angular sector (±rotate° off nominal track) with the
+    DME tolerance ring (0.25 NM fixed + 1.25 % of distance), producing the
+    fix tolerance area per ICAO Doc 8168.
+
+    :param iface: QGIS interface
+    :param navid_layer: Point layer containing the NDB/DME station (NAVID)
+    :param fix_layer: Point layer containing the fix/threshold point
+    :param params: Optional dict; supports key 'rotate' (half-angle in degrees, default 6.9)
+    :return: True on success, False on failure
+    """
+    if params is None:
+        params = {}
+    rotate = float(params.get('rotate', 6.9))
+
+    map_crs = iface.mapCanvas().mapSettings().destinationCrs()
+    map_srid = map_crs.authid()
+    project = QgsProject.instance()
+
+    def show_error(msg):
+        iface.messageBar().pushMessage("QPANSOPY:", msg, level=Qgis.Critical)
+
+    navid_feature = get_selected_feature(navid_layer, show_error)
+    if navid_feature is None:
+        return False
+
+    fix_feature = get_selected_feature(fix_layer, show_error)
+    if fix_feature is None:
+        return False
+
+    # Transform both points to map CRS so calculations and output layer match
+    navid_geom = _geom_to_map_crs(navid_feature, navid_layer, map_crs, project)
+    fix_geom = _geom_to_map_crs(fix_feature, fix_layer, map_crs, project)
+
+    # Azimuth and map-unit distance (used for sector geometry)
+    azimuth = navid_geom.azimuth(fix_geom)
+    length0 = navid_geom.distance(fix_geom)  # map units
+
+    # Ellipsoidal distance in metres (for tolerance formula and Distance_NM)
+    da = QgsDistanceArea()
+    da.setSourceCrs(map_crs, project.transformContext())
+    da.setEllipsoid(project.ellipsoid())
+    length0_m = da.measureLine(navid_geom, fix_geom)
+
+    distance_nm = round(length0_m / 1852, 3)
+
+    # DME tolerance in metres → convert to map units via the ratio
+    dme_tol_m = 0.25 * 1852 + 0.0125 * length0_m
+    dme_tolerance = (dme_tol_m / length0_m) * length0 if length0_m > 0 else dme_tol_m
+
+    # NDB sector triangle: apex at NAVID, ±rotate° for 5× the nominal distance
+    pt1 = QgsPoint(navid_geom)
+    proj2 = navid_geom.project(length0 * 5, azimuth + rotate)
+    proj3 = navid_geom.project(length0 * 5, azimuth - rotate)
+    pt2 = QgsPoint(proj2)
+    pt3 = QgsPoint(proj3)
+    sector = QgsGeometry(QgsPolygon(QgsLineString([pt1, pt2, pt3])))
+
+    # DME tolerance ring: circle of radius = distance, buffered by tolerance
+    dme_circle = QgsGeometry(
+        QgsCircle(QgsPoint(navid_geom), length0).toCircularString()
+    ).buffer(dme_tolerance, 360)
+
+    tolerance_area = sector.intersection(dme_circle)
+
+    # Build result layer
+    v_layer = QgsVectorLayer(f"Polygon?crs={map_srid}", "NDBDME_tolerance", "memory")
+    pr = v_layer.dataProvider()
+    pr.addAttributes([
+        QgsField('Symbol', QVariant.String),
+        QgsField('Distance_NM', QVariant.Double),
+    ])
+    v_layer.updateFields()
+
+    seg = QgsFeature()
+    seg.setGeometry(tolerance_area)
+    seg.setAttributes(['NDB/DME Tolerance', distance_nm])
+    pr.addFeatures([seg])
+    v_layer.updateExtents()
+
+    v_layer.renderer().symbol().setOpacity(0.3)
+    v_layer.renderer().symbol().setColor(QColor('blue'))
+    v_layer.triggerRepaint()
+
+    QgsProject.instance().addMapLayer(v_layer)
+    iface.messageBar().pushMessage(
+        "QPANSOPY:", "NDB/DME Tolerance calculated successfully", level=Qgis.Success
+    )
+    return True

--- a/Q_Pansopy/qpansopy.py
+++ b/Q_Pansopy/qpansopy.py
@@ -44,6 +44,7 @@ try:
     from .dockwidgets.conv.qpansopy_vor_dockwidget import QPANSOPYVORDockWidget
     from .dockwidgets.conv.qpansopy_ndb_dockwidget import QPANSOPYNDBDockWidget
     from .dockwidgets.conv.qpansopy_conv_initial_dockwidget import QPANSOPYConvInitialDockWidget
+    from .dockwidgets.conv.qpansopy_ndb_dme_tolerance_dockwidget import QPANSOPYNDBDMEToleranceDockWidget
     from .dockwidgets.departures.qpansopy_sid_initial_dockwidget import QPANSOPYSIDInitialDockWidget
     from .dockwidgets.departures.qpansopy_omnidirectional_dockwidget import QPANSOPYOmnidirectionalDockWidget
     from .settings_dialog import SettingsDialog  # Import settings dialog
@@ -237,6 +238,14 @@ class Qpansopy:
                     "TOOLTIP": "CONV Initial Approach Straight Areas Tool",
                     "ICON": os.path.join(self.icons_dir, 'conv_corridor.svg'),
                     "DOCK_WIDGET": QPANSOPYConvInitialDockWidget,
+                    "GUI_INSTANCE": None
+                },
+                "NDB_DME_TOL": {
+                    "TITLE": "NDB/DME Tol",
+                    "TOOLBAR": "CONV",
+                    "TOOLTIP": "NDB/DME Tolerance Tool — sector × DME ring intersection",
+                    "ICON": os.path.join(self.icons_dir, 'ndb_dme_tolerance.svg'),
+                    "DOCK_WIDGET": QPANSOPYNDBDMEToleranceDockWidget,
                     "GUI_INSTANCE": None
                 },
                 "ObjectSelection": {

--- a/Q_Pansopy/ui/conv/qpansopy_ndb_dme_tolerance_dockwidget.ui
+++ b/Q_Pansopy/ui/conv/qpansopy_ndb_dme_tolerance_dockwidget.ui
@@ -1,0 +1,230 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QPANSOPYNDBDMEToleranceDockWidget</class>
+ <widget class="QDockWidget" name="QPANSOPYNDBDMEToleranceDockWidget">
+  <property name="minimumSize">
+   <size>
+    <width>250</width>
+    <height>200</height>
+   </size>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>16777215</width>
+    <height>16777215</height>
+   </size>
+  </property>
+  <widget class="QWidget" name="dockWidgetContents">
+   <layout class="QVBoxLayout" name="verticalLayout">
+    <property name="spacing">
+     <number>1</number>
+    </property>
+    <property name="margin">
+     <number>2</number>
+    </property>
+    <item>
+     <widget class="QGroupBox" name="inputGroup">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="title">
+       <string>Input Layers</string>
+      </property>
+      <layout class="QVBoxLayout" name="inputLayout">
+       <property name="spacing">
+        <number>2</number>
+       </property>
+       <property name="margin">
+        <number>4</number>
+       </property>
+       <item>
+        <widget class="QLabel" name="pointLayerLabel">
+         <property name="text">
+          <string>NDB Point Layer</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QgsMapLayerComboBox" name="pointLayerComboBox">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="fixLayerLabel">
+         <property name="text">
+          <string>Fix Point Layer</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QgsMapLayerComboBox" name="fixLayerComboBox">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="fixLayerHintLabel">
+         <property name="text">
+          <string>⚑ Output polygon is drawn at the Fix point location</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+         <property name="styleSheet">
+          <string>color: #888888; font-size: 10px;</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </item>
+    <item>
+     <widget class="QGroupBox" name="paramsGroup">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="title">
+       <string>Parameters</string>
+      </property>
+      <layout class="QFormLayout" name="paramsLayout">
+       <property name="spacing">
+        <number>2</number>
+       </property>
+       <property name="margin">
+        <number>4</number>
+       </property>
+       <item row="0" column="0">
+        <widget class="QLabel" name="rotateLabel">
+         <property name="text">
+          <string>Sector Angle (°)</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QDoubleSpinBox" name="rotateDoubleSpinBox">
+         <property name="minimum">
+          <double>1.000000000000000</double>
+         </property>
+         <property name="maximum">
+          <double>15.000000000000000</double>
+         </property>
+         <property name="singleStep">
+          <double>0.100000000000000</double>
+         </property>
+         <property name="value">
+          <double>6.900000000000000</double>
+         </property>
+         <property name="decimals">
+          <number>1</number>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </item>
+    <item>
+     <widget class="QGroupBox" name="actionGroup">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="title">
+       <string>Actions</string>
+      </property>
+      <layout class="QVBoxLayout" name="actionLayout">
+       <property name="spacing">
+        <number>2</number>
+       </property>
+       <property name="margin">
+        <number>4</number>
+       </property>
+       <item>
+        <widget class="QPushButton" name="calculateButton">
+         <property name="text">
+          <string>Calculate NDB/DME Tolerance</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </item>
+    <item>
+     <widget class="QGroupBox" name="logGroup">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="title">
+       <string>Log</string>
+      </property>
+      <layout class="QVBoxLayout" name="logLayout">
+       <property name="spacing">
+        <number>2</number>
+       </property>
+       <property name="margin">
+        <number>4</number>
+       </property>
+       <item>
+        <widget class="QTextEdit" name="logTextEdit">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>1</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumHeight">
+          <number>100</number>
+         </property>
+         <property name="readOnly">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </item>
+    <item>
+     <spacer name="verticalSpacer">
+      <property name="orientation">
+       <enum>Qt::Vertical</enum>
+      </property>
+      <property name="sizeHint" stdset="0">
+       <size>
+        <width>20</width>
+        <height>20</height>
+       </size>
+      </property>
+     </spacer>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsMapLayerComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgsmaplayercombobox.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
# PR — Add NDB/DME Tolerance Tool (Issue #161)

## Summary

- Adds an NDB/DME fix tolerance dockwidget to the **CONV** toolbar, following the same
  4-artifact pattern used by all existing CONV tools.
- Geometry is identical to the VOR/DME tolerance tool (issue #86) — the only functional
  difference is the default sector half-angle: **6.9°** (NDB) vs 5.2° (VOR).
- Includes a live canvas preview (rubber band) that renders the tolerance polygon as soon
  as both point features are selected, without clicking Calculate.
- CRS-safe: feature geometries are transformed to the map CRS before calculation, and
  `QgsDistanceArea` is used for the DME tolerance formula so the result is correct in
  both geographic (WGS84) and projected CRS.

## Root cause / motivation

ICAO Doc 8168 defines a wider sector angle for NDB fixes (6.9°) compared to VOR (5.2°)
because NDB bearing accuracy is lower. The existing VOR/DME tool could not be reused
directly since the default angle is hardcoded. A dedicated tool was requested in issue #161.

## Implementation notes

### Geometry (same as VOR/DME, different default angle)
1. **NDB sector** — triangle with apex at the NDB station, arms extending 5× the fix
   distance at ±`rotate`° (default 6.9°) off the NAVID→Fix azimuth.
2. **DME tolerance ring** — annulus around the nominal DME arc, tolerance radius
   `0.25 NM + 1.25 % of distance`, built with `QgsCircle.toCircularString().buffer()`.

### CRS handling
```python
# Ellipsoidal distance in metres for the tolerance formula
da = QgsDistanceArea()
da.setSourceCrs(map_crs, project.transformContext())
da.setEllipsoid(project.ellipsoid())
length0_m = da.measureLine(navid_geom, fix_geom)

# Convert to map units for geometry operations
dme_tol_m = 0.25 * 1852 + 0.0125 * length0_m
dme_tolerance = (dme_tol_m / length0_m) * length0
```

### Live preview
`QgsRubberBand` updates on every `selectionChanged` signal from either layer and on
every `valueChanged` from the sector angle spinbox. The rubber band is cleared on
Calculate (replaced by the permanent layer) and on dock close.

## Files Added

| File | Description |
|---|---|
| `Q_Pansopy/modules/conv/ndb_dme_tolerance.py` | Calculation function `run_ndb_dme_tolerance()` |
| `Q_Pansopy/ui/conv/qpansopy_ndb_dme_tolerance_dockwidget.ui` | Qt Designer UI — two point-layer combos, sector angle spinbox (default 6.9°), log |
| `Q_Pansopy/dockwidgets/conv/qpansopy_ndb_dme_tolerance_dockwidget.py` | Dockwidget class with live rubber-band preview |
| `Q_Pansopy/icons/ndb_dme_tolerance.svg` | Aviation-themed toolbar icon (wider sector + DME arc + NDB station ring) |
| `docs/plan-161.md` | Implementation plan |

## Files Modified

| File | Change |
|---|---|
| `Q_Pansopy/qpansopy.py` | Import `QPANSOPYNDBDMEToleranceDockWidget`; add `"NDB_DME_TOL"` entry in `self.modules` under CONV toolbar after `"CONV_INITIAL"` |

## Test plan

- [x] 123 unit tests pass, 1 skipped — no regressions (`pytest tests/ -q`).
- [x] Flake8: 0 findings on new files.
- [ ] CONV toolbar shows new "NDB/DME Tol" button after plugin reload.
- [ ] Select an NDB feature and a Fix feature — rubber-band preview appears on the canvas near the Fix before clicking Calculate.
- [ ] Changing the Sector Angle spinbox updates the preview in real time.
- [ ] Click Calculate — "NDBDME_tolerance" polygon layer appears in blue (~30 % opacity) at the Fix location; attribute table contains `Symbol` and `Distance_NM`.
- [ ] Default sector angle is 6.9° (wider than VOR's 5.2° — visually noticeable).
- [ ] Layers in WGS84 (geographic CRS) — output polygon appears at the correct Fix location, not displaced.
- [ ] Close dock via X and re-open — rubber band is cleared, fresh dock opens.

## Related

Closes #161.
