### PR TITLE
Fix VOR/DME (#86) and NDB/DME (#161) Tolerance tool follow-up bugs

### DIFF
--- a/Q_Pansopy/dockwidgets/conv/qpansopy_ndb_dme_tolerance_dockwidget.py
+++ b/Q_Pansopy/dockwidgets/conv/qpansopy_ndb_dme_tolerance_dockwidget.py
@@ -6,7 +6,7 @@ from qgis.PyQt.QtGui import QColor
 from qgis.gui import QgsRubberBand
 from qgis.core import (
     QgsGeometry, QgsPoint, QgsLineString, QgsPolygon, QgsCircle,
-    QgsProject, QgsDistanceArea, QgsCoordinateTransform,
+    QgsProject, QgsDistanceArea, QgsCoordinateTransform, Qgis,
 )
 from ...qt_compat import (
     MLPM_PointLayer,
@@ -80,6 +80,9 @@ class QPANSOPYNDBDMEToleranceDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         if not navid_layer or not fix_layer:
             return
 
+        if navid_layer.selectedFeatureCount() > 1 or fix_layer.selectedFeatureCount() > 1:
+            return
+
         navid_sel = navid_layer.selectedFeatures()
         fix_sel = fix_layer.selectedFeatures()
         if not navid_sel or not fix_sel:
@@ -139,6 +142,17 @@ class QPANSOPYNDBDMEToleranceDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
             return
         if not fix_layer:
             self.log("Error: Please select a Fix point layer")
+            return
+
+        if navid_layer.selectedFeatureCount() > 1:
+            msg = 'Select exactly one feature in the NAVID layer before calculating'
+            self.log(f'Error: {msg}')
+            self.iface.messageBar().pushMessage('QPANSOPY', msg, level=Qgis.Warning)
+            return
+        if fix_layer.selectedFeatureCount() > 1:
+            msg = 'Select exactly one feature in the Fix layer before calculating'
+            self.log(f'Error: {msg}')
+            self.iface.messageBar().pushMessage('QPANSOPY', msg, level=Qgis.Warning)
             return
 
         params = {'rotate': self.rotateDoubleSpinBox.value()}

--- a/Q_Pansopy/dockwidgets/conv/qpansopy_vor_dme_tolerance_dockwidget.py
+++ b/Q_Pansopy/dockwidgets/conv/qpansopy_vor_dme_tolerance_dockwidget.py
@@ -6,7 +6,7 @@ from qgis.PyQt.QtGui import QColor
 from qgis.gui import QgsRubberBand
 from qgis.core import (
     QgsGeometry, QgsPoint, QgsLineString, QgsPolygon, QgsCircle,
-    QgsProject, QgsDistanceArea, QgsCoordinateTransform,
+    QgsProject, QgsDistanceArea, QgsCoordinateTransform, Qgis,
 )
 from ...qt_compat import (
     MLPM_PointLayer,
@@ -80,6 +80,9 @@ class QPANSOPYVORDMEToleranceDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         if not navid_layer or not fix_layer:
             return
 
+        if navid_layer.selectedFeatureCount() > 1 or fix_layer.selectedFeatureCount() > 1:
+            return
+
         navid_sel = navid_layer.selectedFeatures()
         fix_sel = fix_layer.selectedFeatures()
         if not navid_sel or not fix_sel:
@@ -139,6 +142,17 @@ class QPANSOPYVORDMEToleranceDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
             return
         if not fix_layer:
             self.log("Error: Please select a Fix point layer")
+            return
+
+        if navid_layer.selectedFeatureCount() > 1:
+            msg = 'Select exactly one feature in the NAVID layer before calculating'
+            self.log(f'Error: {msg}')
+            self.iface.messageBar().pushMessage('QPANSOPY', msg, level=Qgis.Warning)
+            return
+        if fix_layer.selectedFeatureCount() > 1:
+            msg = 'Select exactly one feature in the Fix layer before calculating'
+            self.log(f'Error: {msg}')
+            self.iface.messageBar().pushMessage('QPANSOPY', msg, level=Qgis.Warning)
             return
 
         params = {'rotate': self.rotateDoubleSpinBox.value()}

--- a/Q_Pansopy/metadata.txt
+++ b/Q_Pansopy/metadata.txt
@@ -23,6 +23,8 @@ changelog=
  - Fix Holding Pattern Direcion
  - Inclusion of VOR/DME Tolerance creation
  - Inclusion of NDB/DME Tolerance creation
+ - Fix NDB/DME Tolerance tool not appearing in the CONV toolbar
+ - Require exactly one selected feature per layer in VOR/DME and NDB/DME Tolerance tools
  Version 0.4.0:
  - Fixes to initial realease to code logic including QGIS Plugin Store Compliance
  - PBN 15 NM and 30 NM targets included

--- a/Q_Pansopy/qpansopy.py
+++ b/Q_Pansopy/qpansopy.py
@@ -45,6 +45,7 @@ try:
     from .dockwidgets.conv.qpansopy_ndb_dockwidget import QPANSOPYNDBDockWidget
     from .dockwidgets.conv.qpansopy_conv_initial_dockwidget import QPANSOPYConvInitialDockWidget
     from .dockwidgets.conv.qpansopy_vor_dme_tolerance_dockwidget import QPANSOPYVORDMEToleranceDockWidget
+    from .dockwidgets.conv.qpansopy_ndb_dme_tolerance_dockwidget import QPANSOPYNDBDMEToleranceDockWidget
     from .dockwidgets.departures.qpansopy_sid_initial_dockwidget import QPANSOPYSIDInitialDockWidget
     from .dockwidgets.departures.qpansopy_omnidirectional_dockwidget import QPANSOPYOmnidirectionalDockWidget
     from .settings_dialog import SettingsDialog  # Import settings dialog
@@ -246,6 +247,14 @@ class Qpansopy:
                     "TOOLTIP": "VOR/DME Tolerance Tool — sector × DME ring intersection",
                     "ICON": os.path.join(self.icons_dir, 'vor_dme_tolerance.svg'),
                     "DOCK_WIDGET": QPANSOPYVORDMEToleranceDockWidget,
+                    "GUI_INSTANCE": None
+                },
+                "NDB_DME_TOL": {
+                    "TITLE": "NDB/DME Tol",
+                    "TOOLBAR": "CONV",
+                    "TOOLTIP": "NDB/DME Tolerance Tool — sector × DME ring intersection",
+                    "ICON": os.path.join(self.icons_dir, 'ndb_dme_tolerance.svg'),
+                    "DOCK_WIDGET": QPANSOPYNDBDMEToleranceDockWidget,
                     "GUI_INSTANCE": None
                 },
                 "ObjectSelection": {


### PR DESCRIPTION
# PR — Fix VOR/DME (#86) and NDB/DME (#161) Tolerance tool follow-up bugs

## Summary

- Registers the **NDB/DME Tolerance** tool in `qpansopy.py` — the dockwidget class and icon
  existed on disk but were never imported/registered, so no toolbar button was ever created.
- Adds explicit "exactly one selected feature" validation to both **VOR/DME** and **NDB/DME**
  Tolerance dockwidgets, for both the live preview and the Calculate action.
- No behavior change for the existing single-feature happy path.

## Root cause / motivation

Both tools were merged in #162 and #163, but testing surfaced two follow-up issues:

1. **#86**: selecting more than one point per layer had no clear, upfront feedback — the
   module-level `get_selected_feature()` already rejects >1 selected when Calculate is
   clicked, but the live preview silently drew from an arbitrary selected feature
   (`selectedFeatures()[0]`) with no warning at all.
2. **#161**: "Can't see the icon to create NDB tolerance" — `Q_Pansopy/qpansopy.py` imports
   and registers `QPANSOPYVORDMEToleranceDockWidget` (`"VOR_DME_TOL"` entry) but never did the
   same for `QPANSOPYNDBDMEToleranceDockWidget`, so the CONV toolbar never got an NDB/DME
   button even though the changelog already (incorrectly) listed it as included.

## Implementation notes

### NDB/DME registration
Mirrors the existing `"VOR_DME_TOL"` entry exactly:
```python
from .dockwidgets.conv.qpansopy_ndb_dme_tolerance_dockwidget import QPANSOPYNDBDMEToleranceDockWidget
...
"NDB_DME_TOL": {
    "TITLE": "NDB/DME Tol",
    "TOOLBAR": "CONV",
    "TOOLTIP": "NDB/DME Tolerance Tool — sector × DME ring intersection",
    "ICON": os.path.join(self.icons_dir, 'ndb_dme_tolerance.svg'),
    "DOCK_WIDGET": QPANSOPYNDBDMEToleranceDockWidget,
    "GUI_INSTANCE": None
},
```

### Explicit single-selection validation
Applied identically to both dockwidgets, following the same pattern already used in
`qpansopy_holding_dockwidget.py`:

```python
if navid_layer.selectedFeatureCount() > 1:
    msg = 'Select exactly one feature in the NAVID layer before calculating'
    self.log(f'Error: {msg}')
    self.iface.messageBar().pushMessage('QPANSOPY', msg, level=Qgis.Warning)
    return
```

`_update_preview()` now bails out (no rubber band drawn) when either layer has more than one
feature selected, instead of silently picking `selectedFeatures()[0]`:

```python
if navid_layer.selectedFeatureCount() > 1 or fix_layer.selectedFeatureCount() > 1:
    return
```

No new UI control (e.g. a "use selected feature only" checkbox) was added — the existing
0-selected/1-in-layer auto-pick fallback in `get_selected_feature()` (`Q_Pansopy/utils.py`) is
intentional and untouched; only the previously-silent multi-selection case is now explicit in
both the preview and the Calculate action.

## Files Modified

| File | Change |
|---|---|
| `Q_Pansopy/qpansopy.py` | Import `QPANSOPYNDBDMEToleranceDockWidget`; add `"NDB_DME_TOL"` entry in `self.modules` under CONV toolbar |
| `Q_Pansopy/dockwidgets/conv/qpansopy_vor_dme_tolerance_dockwidget.py` | Add `Qgis` import; guard `calculate()` and `_update_preview()` against >1 selected feature per layer |
| `Q_Pansopy/dockwidgets/conv/qpansopy_ndb_dme_tolerance_dockwidget.py` | Same as above |
| `Q_Pansopy/metadata.txt` | Two changelog bullets under Version 0.4.1 |
| `docs/plan-86-161.md` | Implementation plan |

## Test plan

- [x] 123 unit tests pass, 1 skipped — no regressions (`pytest tests/ -q`).
- [x] Flake8: 0 findings on all three changed Python files.
- [ ] CONV toolbar shows a new "NDB/DME Tol" button after plugin reload, alongside "VOR/DME Tol".
- [ ] VOR/DME: select 2+ features in NAVID or Fix layer → preview disappears; Calculate logs a
  warning and does not run.
- [ ] NDB/DME: same check as above.
- [ ] Both tools: selecting exactly 1 feature (or 0 with only 1 feature present in the layer)
  in each layer behaves exactly as before — preview shown, Calculate succeeds.

## Related

Closes #86. Closes #161.
