### PR TITLE
OMNI SID feet/meters unit toggle + parameter panel alignment (Issue #166)

### DIFF
--- a/Q_Pansopy/dockwidgets/departures/qpansopy_omnidirectional_dockwidget.py
+++ b/Q_Pansopy/dockwidgets/departures/qpansopy_omnidirectional_dockwidget.py
@@ -63,10 +63,12 @@ class QPANSOPYOmnidirectionalDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
 
         # Set default values
         self.derElevationSpinBox.setValue(0.0)
+        self.derElevationUnitCombo.setCurrentText('m')
         self.pdgSpinBox.setValue(3.3)
         self.tnaSpinBox.setValue(2000)
         self.msaSpinBox.setValue(6300)
         self.cwyDistanceSpinBox.setValue(0)
+        self.cwyDistanceUnitCombo.setCurrentText('m')
 
         # Ensure checkboxes exist
         if not hasattr(self, "exportKmlCheckBox") or self.exportKmlCheckBox is None:
@@ -149,10 +151,12 @@ class QPANSOPYOmnidirectionalDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         # Prepare parameters
         params = {
             'der_elevation_m': self.derElevationSpinBox.value(),
+            'der_elevation_unit': self.derElevationUnitCombo.currentText(),
             'pdg': self.pdgSpinBox.value(),
             'TNA_ft': self.tnaSpinBox.value(),
             'msa_ft': self.msaSpinBox.value(),
             'cwy_distance_m': self.cwyDistanceSpinBox.value(),
+            'cwy_distance_unit': self.cwyDistanceUnitCombo.currentText(),
             'allow_turns_before_der': 'YES' if self.turnsBeforeDerCheckBox.isChecked() else 'NO',
             'include_construction_points': 'YES' if self.constructionPointsCheckBox.isChecked() else 'NO',
             'reverse_direction': 'YES' if self.is_reversed else 'NO'

--- a/Q_Pansopy/metadata.txt
+++ b/Q_Pansopy/metadata.txt
@@ -23,6 +23,7 @@ changelog=
  - Fix Holding Pattern Direcion
  - Inclusion of VOR/DME Tolerance creation
  - Inclusion of NDB/DME Tolerance creation
+ - Add meters/feet unit selector for DER Elevation and CWY Distance in the OMNI SID tool
  Version 0.4.0:
  - Fixes to initial realease to code logic including QGIS Plugin Store Compliance
  - PBN 15 NM and 30 NM targets included

--- a/Q_Pansopy/modules/departures/omnidirectional_sid.py
+++ b/Q_Pansopy/modules/departures/omnidirectional_sid.py
@@ -243,11 +243,15 @@ def run_omnidirectional_sid(iface, runway_layer, params, log_callback=None):
             Must have a selected feature representing the runway centerline.
             The line should be oriented from threshold to DER (Departure End of Runway).
         params (dict): Dictionary containing calculation parameters:
-            - der_elevation_m (float): DER elevation above MSL in meters.
+            - der_elevation_m (float): DER elevation above MSL, in the unit given by
+                der_elevation_unit.
+            - der_elevation_unit (str, optional): 'm' or 'ft'. Defaults to 'm'.
             - pdg (float): Procedure Design Gradient in percent (e.g., 3.3).
             - TNA_ft (float): Turn Altitude in feet.
             - msa_ft (float): Minimum Sector Altitude in feet.
-            - cwy_distance_m (float): Clearway distance beyond DER in meters.
+            - cwy_distance_m (float): Clearway distance beyond DER, in the unit given
+                by cwy_distance_unit.
+            - cwy_distance_unit (str, optional): 'm' or 'ft'. Defaults to 'm'.
             - allow_turns_before_der (str): 'YES' or 'NO' - whether to include
                 the area before DER for turns.
             - include_construction_points (str): 'YES' or 'NO' - whether to
@@ -298,11 +302,17 @@ def run_omnidirectional_sid(iface, runway_layer, params, log_callback=None):
     # -------------------------------------------------------------------------
     # Extract and validate parameters
     # -------------------------------------------------------------------------
-    der_elevation_m = float(params.get('der_elevation_m', 0))
+    der_elevation_raw = float(params.get('der_elevation_m', 0))
+    der_elevation_unit = params.get('der_elevation_unit', 'm')
+    der_elevation_m = (der_elevation_raw if der_elevation_unit == 'm'
+                       else feet_to_meters(der_elevation_raw))
     pdg_percent = float(params.get('pdg', 3.3))
     tna_ft = float(params.get('TNA_ft', 2000))
     msa_ft = float(params.get('msa_ft', 6300))
-    cwy_distance_m = float(params.get('cwy_distance_m', 0))
+    cwy_distance_raw = float(params.get('cwy_distance_m', 0))
+    cwy_distance_unit = params.get('cwy_distance_unit', 'm')
+    cwy_distance_m = (cwy_distance_raw if cwy_distance_unit == 'm'
+                      else feet_to_meters(cwy_distance_raw))
     allow_turns_before_der = params.get('allow_turns_before_der', 'NO')
     include_construction_points = params.get('include_construction_points', 'NO')
     reverse_direction = params.get('reverse_direction', 'NO')

--- a/Q_Pansopy/ui/departures/qpansopy_omnidirectional_dockwidget.ui
+++ b/Q_Pansopy/ui/departures/qpansopy_omnidirectional_dockwidget.ui
@@ -91,25 +91,49 @@
        <item row="0" column="0">
         <widget class="QLabel" name="derElevationLabel">
          <property name="text">
-          <string>DER Elevation (m):</string>
+          <string>DER Elevation:</string>
          </property>
         </widget>
        </item>
        <item row="0" column="1">
-        <widget class="QDoubleSpinBox" name="derElevationSpinBox">
-         <property name="minimum">
-          <double>-500.000000000000000</double>
-         </property>
-         <property name="maximum">
-          <double>5000.000000000000000</double>
-         </property>
-         <property name="singleStep">
-          <double>1.000000000000000</double>
-         </property>
-         <property name="decimals">
-          <number>2</number>
-         </property>
-        </widget>
+        <layout class="QHBoxLayout" name="derElevationLayout">
+         <item>
+          <widget class="QDoubleSpinBox" name="derElevationSpinBox">
+           <property name="minimumWidth">
+            <number>90</number>
+           </property>
+           <property name="minimum">
+            <double>-500.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>20000.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>1.000000000000000</double>
+           </property>
+           <property name="decimals">
+            <number>2</number>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="derElevationUnitCombo">
+           <property name="maximumWidth">
+            <number>55</number>
+           </property>
+           <item>
+            <property name="text">
+             <string>m</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>ft</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+        </layout>
        </item>
        <item row="1" column="0">
         <widget class="QLabel" name="pdgLabel">
@@ -120,6 +144,9 @@
        </item>
        <item row="1" column="1">
         <widget class="QDoubleSpinBox" name="pdgSpinBox">
+         <property name="minimumWidth">
+          <number>90</number>
+         </property>
          <property name="minimum">
           <double>0.100000000000000</double>
          </property>
@@ -146,6 +173,9 @@
        </item>
        <item row="2" column="1">
         <widget class="QSpinBox" name="tnaSpinBox">
+         <property name="minimumWidth">
+          <number>90</number>
+         </property>
          <property name="minimum">
           <number>0</number>
          </property>
@@ -169,6 +199,9 @@
        </item>
        <item row="3" column="1">
         <widget class="QSpinBox" name="msaSpinBox">
+         <property name="minimumWidth">
+          <number>90</number>
+         </property>
          <property name="minimum">
           <number>0</number>
          </property>
@@ -186,25 +219,49 @@
        <item row="4" column="0">
         <widget class="QLabel" name="cwyDistanceLabel">
          <property name="text">
-          <string>CWY Distance (m):</string>
+          <string>CWY Distance:</string>
          </property>
         </widget>
        </item>
        <item row="4" column="1">
-        <widget class="QSpinBox" name="cwyDistanceSpinBox">
-         <property name="minimum">
-          <number>0</number>
-         </property>
-         <property name="maximum">
-          <number>5000</number>
-         </property>
-         <property name="singleStep">
-          <number>10</number>
-         </property>
-         <property name="value">
-          <number>150</number>
-         </property>
-        </widget>
+        <layout class="QHBoxLayout" name="cwyDistanceLayout">
+         <item>
+          <widget class="QSpinBox" name="cwyDistanceSpinBox">
+           <property name="minimumWidth">
+            <number>90</number>
+           </property>
+           <property name="minimum">
+            <number>0</number>
+           </property>
+           <property name="maximum">
+            <number>5000</number>
+           </property>
+           <property name="singleStep">
+            <number>10</number>
+           </property>
+           <property name="value">
+            <number>150</number>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="cwyDistanceUnitCombo">
+           <property name="maximumWidth">
+            <number>55</number>
+           </property>
+           <item>
+            <property name="text">
+             <string>m</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>ft</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+        </layout>
        </item>
       </layout>
      </widget>


### PR DESCRIPTION
# PR — OMNI SID feet/meters unit toggle + parameter panel alignment (Issue #166)

## Summary

- Adds a meters/feet unit selector next to **DER Elevation** and **CWY Distance** in the OMNI
  SID tool's Parameters panel — TNA and MSA remain feet-only, as requested.
- Aligns the Parameters panel: all five spinboxes share a consistent minimum width and the two
  new unit combos are a fixed, compact width, so the column of fields reads as uniform.
- No behavior change for existing users — both unit combos default to `m`, matching the
  previous meters-only inputs exactly.
<img width="492" height="579" alt="{33C09C85-CD22-4BA5-8E28-04AC811E7EA7}" src="https://github.com/user-attachments/assets/86e82e69-b98d-47c2-9374-f1820e6c7a75" />

## Root cause

The OMNI SID tool's `parametersFormLayout` had plain label+spinbox rows for DER Elevation and
CWY Distance with the unit hardcoded into the label text (`DER Elevation (m):`,
`CWY Distance (m):`), and the calculation module assumed both values arrived pre-converted to
meters. There was no way to enter either value in feet.

## Implementation notes

### Unit selector (UI)
Each of the two rows now nests a `QHBoxLayout` in its `QFormLayout` field cell — the existing
spinbox plus a new `QComboBox` (`m`/`ft`) — the same structure already used for the Altitude
row in `qpansopy_holding_dockwidget.ui`:
```xml
<item row="0" column="1">
 <layout class="QHBoxLayout" name="derElevationLayout">
  <item><widget class="QDoubleSpinBox" name="derElevationSpinBox">...</widget></item>
  <item><widget class="QComboBox" name="derElevationUnitCombo">
    <item><property name="text"><string>m</string></property></item>
    <item><property name="text"><string>ft</string></property></item>
  </widget></item>
 </layout>
</item>
```
`derElevationSpinBox`'s maximum was raised from `5000` to `20000` so it can hold realistic
values when switched to feet (the world's highest airport elevations run close to 13,000 ft).

### Unit-aware conversion (module)
Follows the same `raw value + <field>_unit` convention already used by `vss_straight.py`,
`vss_loc.py`, and `basic_ils.py`. The dockwidget just forwards the combo's `currentText()`;
`run_omnidirectional_sid()` converts using its own existing `feet_to_meters()` helper (already
used for TNA/MSA):
```python
der_elevation_raw = float(params.get('der_elevation_m', 0))
der_elevation_unit = params.get('der_elevation_unit', 'm')
der_elevation_m = (der_elevation_raw if der_elevation_unit == 'm'
                   else feet_to_meters(der_elevation_raw))
...
cwy_distance_raw = float(params.get('cwy_distance_m', 0))
cwy_distance_unit = params.get('cwy_distance_unit', 'm')
cwy_distance_m = (cwy_distance_raw if cwy_distance_unit == 'm'
                  else feet_to_meters(cwy_distance_raw))
```
Everything downstream of this block (Area 1/2/3 distance and elevation math) is unchanged, since
it already consumed `der_elevation_m`/`cwy_distance_m` in meters.

Switching the combo does not rescale a value already typed in — it only changes how the next
Calculate interprets it, matching the behavior of every other unit combo already in this
codebase (e.g. `qpansopy_ils_dockwidget.py`'s `update_unit()`).

### Alignment
All five Parameters spinboxes got a shared `minimumWidth` (90px) and the two new unit combos a
`maximumWidth` (55px), so the panel presents a visually consistent column of fields instead of
mismatched widths.

## Files Modified

| File | Change |
|---|---|
| `Q_Pansopy/ui/departures/qpansopy_omnidirectional_dockwidget.ui` | Add `derElevationUnitCombo`/`cwyDistanceUnitCombo`; shorten labels; widen DER Elevation max to 20000; uniform field widths |
| `Q_Pansopy/dockwidgets/departures/qpansopy_omnidirectional_dockwidget.py` | Default both unit combos to `m`; add `der_elevation_unit`/`cwy_distance_unit` to `params` |
| `Q_Pansopy/modules/departures/omnidirectional_sid.py` | Read and convert the new unit params via existing `feet_to_meters()`; docstring updated |
| `Q_Pansopy/metadata.txt` | One changelog bullet under Version 0.4.1 |
| `docs/plan-166.md` | Implementation plan |

## Test plan

- [x] `pytest tests/ -q` — no regressions.
- [x] Flake8: 0 new findings on the two changed Python files (two pre-existing findings in the
  dockwidget file predate this change, confirmed present on `main`).
- [ ] Parameters panel shows unit combos next to DER Elevation and CWY Distance, defaulting to
  `m`; TNA/MSA remain feet-only, unchanged.
- [ ] Enter a DER Elevation value with unit `m`, calculate, confirm output areas match current
  (pre-change) behavior.
- [ ] Switch DER Elevation unit to `ft`, enter a feet value, calculate, confirm the log's
  `Parameters: DER Elev=...m` line shows the correctly converted meters value.
- [ ] Same check for CWY Distance in `ft`.
- [ ] Visual check: the five Parameters rows line up with consistent field widths.

## Related

Closes #166.
