### PR TITLE
 OMNI SID live DER marker (rubber band) (Issue #167)

### DIFF
--- a/Q_Pansopy/dockwidgets/departures/qpansopy_omnidirectional_dockwidget.py
+++ b/Q_Pansopy/dockwidgets/departures/qpansopy_omnidirectional_dockwidget.py
@@ -22,8 +22,23 @@ Procedure Analysis - Omnidirectional SID Departure Surface Tool
 import os
 from qgis.PyQt import QtWidgets, uic
 from qgis.PyQt.QtCore import pyqtSignal
-from qgis.core import Qgis
-from ...qt_compat import DOCK_FEATURES_DEFAULT, Qt_ALLOWED_DOCK_AREAS, MLPM_LineLayer, preseed_active_layer, Qgis_GeomType_Line
+from qgis.PyQt.QtGui import QColor
+from qgis.core import (
+    Qgis, QgsGeometry, QgsPoint, QgsPolygon, QgsLineString,
+    QgsProject, QgsCoordinateTransform,
+)
+from qgis.gui import QgsRubberBand
+from ...qt_compat import (
+    DOCK_FEATURES_DEFAULT, Qt_ALLOWED_DOCK_AREAS, MLPM_LineLayer,
+    preseed_active_layer, Qgis_GeomType_Line, Qgis_GeomType_Polygon,
+)
+
+# DER marker arrow dimensions in screen pixels (converted to map units via
+# mapUnitsPerPixel so the marker stays a constant, visible size at any zoom level)
+_DER_MARKER_SHAFT_LENGTH_PX = 40
+_DER_MARKER_SHAFT_HALF_WIDTH_PX = 4
+_DER_MARKER_HEAD_LENGTH_PX = 16
+_DER_MARKER_HEAD_HALF_WIDTH_PX = 12
 
 
 # Use __file__ to get the current script path
@@ -57,7 +72,7 @@ class QPANSOPYOmnidirectionalDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         # Filter layers in comboboxes - Runway layer should be a line
         self.runwayLayerComboBox.setFilters(MLPM_LineLayer)
         preseed_active_layer(iface, self.runwayLayerComboBox, Qgis_GeomType_Line)
-        
+
         # Direction state: False = Start to End, True = End to Start
         self.is_reversed = False
 
@@ -67,6 +82,19 @@ class QPANSOPYOmnidirectionalDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         self.tnaSpinBox.setValue(2000)
         self.msaSpinBox.setValue(6300)
         self.cwyDistanceSpinBox.setValue(0)
+
+        # Live DER marker preview (off by default)
+        self._der_marker_band = QgsRubberBand(iface.mapCanvas(), Qgis_GeomType_Polygon)
+        self._der_marker_band.setColor(QColor(0, 170, 0, 120))
+        self._der_marker_band.setStrokeColor(QColor(0, 120, 0, 220))
+        self._der_marker_band.setWidth(1)
+        self._connected_runway_layer = None
+
+        self.runwayLayerComboBox.layerChanged.connect(self._on_runway_layer_changed)
+        self.cwyDistanceSpinBox.valueChanged.connect(self._update_der_marker)
+        self.showDerMarkerCheckBox.toggled.connect(self._update_der_marker)
+        iface.mapCanvas().scaleChanged.connect(self._update_der_marker)
+        self._on_runway_layer_changed()
 
         # Ensure checkboxes exist
         if not hasattr(self, "exportKmlCheckBox") or self.exportKmlCheckBox is None:
@@ -81,6 +109,11 @@ class QPANSOPYOmnidirectionalDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         self.log("Select runway layer and set parameters, then click Calculate.")
 
     def closeEvent(self, event):
+        self._clear_der_marker()
+        try:
+            self.iface.mapCanvas().scaleChanged.disconnect(self._update_der_marker)
+        except (TypeError, RuntimeError):
+            pass
         self.closingPlugin.emit()
         event.accept()
 
@@ -93,6 +126,84 @@ class QPANSOPYOmnidirectionalDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         else:
             self.directionButton.setText("Start → End")
             self.log("Direction changed: Start to End (normal)")
+        self._update_der_marker()
+
+    def _on_runway_layer_changed(self, *args):
+        if self._connected_runway_layer is not None:
+            try:
+                self._connected_runway_layer.selectionChanged.disconnect(self._update_der_marker)
+            except (TypeError, RuntimeError):
+                pass
+            self._connected_runway_layer = None
+
+        layer = self.runwayLayerComboBox.currentLayer()
+        if layer:
+            layer.selectionChanged.connect(self._update_der_marker)
+            self._connected_runway_layer = layer
+
+        self._update_der_marker()
+
+    def _clear_der_marker(self):
+        if self._der_marker_band:
+            self._der_marker_band.reset(Qgis_GeomType_Polygon)
+
+    def _update_der_marker(self, *args):
+        self._clear_der_marker()
+
+        if not self.showDerMarkerCheckBox.isChecked():
+            return
+
+        runway_layer = self.runwayLayerComboBox.currentLayer()
+        if not runway_layer or runway_layer.selectedFeatureCount() != 1:
+            return
+
+        try:
+            map_crs = self.iface.mapCanvas().mapSettings().destinationCrs()
+            project = QgsProject.instance()
+
+            feature = runway_layer.selectedFeatures()[0]
+            geom = feature.geometry()
+            geom.transform(QgsCoordinateTransform(runway_layer.crs(), map_crs, project))
+            runway_geometry = geom.asPolyline()
+            if len(runway_geometry) < 2:
+                return
+
+            if self.is_reversed:
+                threshold_point = QgsPoint(runway_geometry[1])
+                der_point = QgsPoint(runway_geometry[0])
+            else:
+                threshold_point = QgsPoint(runway_geometry[0])
+                der_point = QgsPoint(runway_geometry[1])
+
+            runway_azimuth = threshold_point.azimuth(der_point)
+            der_cwy_point = der_point.project(self.cwyDistanceSpinBox.value(), runway_azimuth)
+
+            # Size the marker in screen pixels so it stays visible at any zoom level
+            mupp = self.iface.mapCanvas().mapUnitsPerPixel()
+            shaft_length = _DER_MARKER_SHAFT_LENGTH_PX * mupp
+            shaft_half_width = _DER_MARKER_SHAFT_HALF_WIDTH_PX * mupp
+            head_length = _DER_MARKER_HEAD_LENGTH_PX * mupp
+            head_half_width = _DER_MARKER_HEAD_HALF_WIDTH_PX * mupp
+
+            # Arrow tip sits at the DER+CWY point, shaft trails back toward the threshold
+            back_azimuth = runway_azimuth + 180
+            back_point = der_cwy_point.project(shaft_length + head_length, back_azimuth)
+            head_base_point = der_cwy_point.project(head_length, back_azimuth)
+
+            back_left = back_point.project(shaft_half_width, runway_azimuth - 90)
+            back_right = back_point.project(shaft_half_width, runway_azimuth + 90)
+            shaft_head_left = head_base_point.project(shaft_half_width, runway_azimuth - 90)
+            shaft_head_right = head_base_point.project(shaft_half_width, runway_azimuth + 90)
+            head_left = head_base_point.project(head_half_width, runway_azimuth - 90)
+            head_right = head_base_point.project(head_half_width, runway_azimuth + 90)
+
+            arrow = QgsGeometry(QgsPolygon(QgsLineString([
+                back_left, shaft_head_left, head_left, der_cwy_point,
+                head_right, shaft_head_right, back_right,
+            ])))
+            self._der_marker_band.setToGeometry(arrow, None)
+        except Exception:
+            pass
 
     def log(self, message):
         """Add a message to the log"""

--- a/Q_Pansopy/metadata.txt
+++ b/Q_Pansopy/metadata.txt
@@ -25,6 +25,7 @@ changelog=
  - Inclusion of NDB/DME Tolerance creation
  - Fix NDB/DME Tolerance tool not appearing in the CONV toolbar
  - Require exactly one selected feature per layer in VOR/DME and NDB/DME Tolerance tools
+ - Add optional live DER marker (direction + CWY offset) preview to the OMNI SID tool
  Version 0.4.0:
  - Fixes to initial realease to code logic including QGIS Plugin Store Compliance
  - PBN 15 NM and 30 NM targets included

--- a/Q_Pansopy/ui/departures/qpansopy_omnidirectional_dockwidget.ui
+++ b/Q_Pansopy/ui/departures/qpansopy_omnidirectional_dockwidget.ui
@@ -241,6 +241,13 @@
          </property>
         </widget>
        </item>
+       <item>
+        <widget class="QCheckBox" name="showDerMarkerCheckBox">
+         <property name="text">
+          <string>Show DER marker</string>
+         </property>
+        </widget>
+       </item>
       </layout>
      </widget>
     </item>


### PR DESCRIPTION
# PR — OMNI SID live DER marker (rubber band) (Issue #167)

## Summary

- Adds an optional, off-by-default "Show DER marker" checkbox to the OMNI SID tool that draws
  a live green arrow on the map canvas at the DER, offset by the CWY (clearway) distance,
  pointing in the direction of flight.
- Updates live as the user changes the runway selection, the CWY Distance value, or toggles the
  Start→End/End→Start direction — before Calculate is ever clicked.
- No behavior change for existing users — the checkbox defaults to unchecked and nothing new is
  read by `calculate()` or passed to the calculation module.
<img width="384" height="525" alt="{9EDE5C40-18E5-4D13-AF6E-D63C67A38DC2}" src="https://github.com/user-attachments/assets/dae50add-2a1d-4c4c-8237-9a3c9bece55b" />

## Root cause / motivation

The OMNI SID tool had no visual feedback for where the DER actually sits or which direction the
procedure will fly until after running a full calculation. The reporter (antoniolocandro) asked
for a lightweight live indicator — a triangle/arrow accounting for the CWY offset — to sanity-
check the direction toggle and CWY value up front.

## Implementation notes

### Reusing the module's own DER+CWY point math
`Q_Pansopy/modules/departures/omnidirectional_sid.py` already computes the exact point this
marker needs (`point_0_center`, built via `der_point.project(cwy_distance_m, runway_azimuth)`
at line 391-395). The dockwidget's new `_update_der_marker()` replicates the same
direction-aware point/azimuth logic (`omnidirectional_sid.py:365-374`) so the live preview
always matches what Calculate would actually produce, then builds a 7-point **arrow polygon**
(shaft + flared arrowhead, tip at the DER+CWY point) from that point using the same
`.project(distance, azimuth)` primitive, matching the reporter's reference image rather than a
plain triangle:
```python
if self.is_reversed:
    threshold_point = QgsPoint(runway_geometry[1])
    der_point = QgsPoint(runway_geometry[0])
else:
    threshold_point = QgsPoint(runway_geometry[0])
    der_point = QgsPoint(runway_geometry[1])

runway_azimuth = threshold_point.azimuth(der_point)
der_cwy_point = der_point.project(self.cwyDistanceSpinBox.value(), runway_azimuth)

back_point = der_cwy_point.project(shaft_length + head_length, runway_azimuth + 180)
head_base_point = der_cwy_point.project(head_length, runway_azimuth + 180)
# ... left/right offsets at back_point and head_base_point via .project(width, azimuth ± 90)
arrow = QgsGeometry(QgsPolygon(QgsLineString([
    back_left, shaft_head_left, head_left, der_cwy_point,
    head_right, shaft_head_right, back_right,
])))
```
Always rendered green (`QColor(0, 170, 0, 120)` fill, `QColor(0, 120, 0, 220)` stroke) — the
reporter's reference screenshot used red only to annotate the desired arrow shape, not color.

### Live preview wiring
Follows the same `QgsRubberBand` + signal-rewiring pattern already used in
`qpansopy_vor_dme_tolerance_dockwidget.py`/`qpansopy_ndb_dme_tolerance_dockwidget.py`:
`_on_runway_layer_changed()` disconnects the previous layer's `selectionChanged` and reconnects
it on the newly-selected layer; `cwyDistanceSpinBox.valueChanged`, `showDerMarkerCheckBox.toggled`,
and `toggle_direction()` all trigger `_update_der_marker()`; `closeEvent()` clears the band.

### Zoom-independent marker size
An earlier version sized the triangle in fixed map units (meters), which shrank to invisible
when zoomed out far enough to see the whole procedure — exactly the "no se ve desde lejos"
problem reported during manual testing. The triangle is now sized in **screen pixels** and
converted to map units via `mapCanvas().mapUnitsPerPixel()` on every redraw, with
`mapCanvas().scaleChanged` wired to `_update_der_marker()` (and disconnected in `closeEvent()`)
so it keeps a constant, clearly visible on-screen size at any zoom level:
```python
map_units_per_pixel = self.iface.mapCanvas().mapUnitsPerPixel()
marker_length = _DER_MARKER_LENGTH_PX * map_units_per_pixel
marker_half_width = _DER_MARKER_HALF_WIDTH_PX * map_units_per_pixel
```

### Scope
The checkbox state is purely a UI/preview concern — `calculate()` and
`run_omnidirectional_sid()` are unchanged; nothing new is added to `params`.

## Files Modified

| File | Change |
|---|---|
| `Q_Pansopy/ui/departures/qpansopy_omnidirectional_dockwidget.ui` | Add `showDerMarkerCheckBox` to the Options group |
| `Q_Pansopy/dockwidgets/departures/qpansopy_omnidirectional_dockwidget.py` | Add live DER marker rubber band, wiring, and update logic |
| `Q_Pansopy/metadata.txt` | One changelog bullet under Version 0.4.1 |
| `docs/plan-167.md` | Implementation plan |

## Test plan

- [x] `pytest tests/ -q` — no regressions.
- [x] Flake8: 0 findings on the changed Python file.
- [ ] "Show DER marker" checkbox is present and unchecked by default; nothing is drawn until
  checked.
- [ ] With a runway feature selected and the checkbox checked, a green triangle appears offset
  from the runway end by the CWY distance, apex pointing in the direction of flight.
- [ ] Toggling Start→End/End→Start flips the marker's position and orientation to the other end
  of the runway.
- [ ] Changing the CWY Distance spinbox live-updates the marker's offset distance.
- [ ] Selecting a different runway feature (or none) updates/clears the marker correctly;
  closing the dock removes the marker from the canvas.

## Related

Closes #167.
