### PR TITLE
LNAV tool silently fails when Routing layer lacks a "segment" field (Issue #168)

### DIFF
--- a/Q_Pansopy/metadata.txt
+++ b/Q_Pansopy/metadata.txt
@@ -26,6 +26,7 @@ changelog=
  - Fix NDB/DME Tolerance tool not appearing in the CONV toolbar
  - Require exactly one selected feature per layer in VOR/DME and NDB/DME Tolerance tools
  - Add optional live DER marker (direction + CWY offset) preview to the OMNI SID tool
+ - Show a clear error when the LNAV Routing layer is missing the required 'segment' field
  Version 0.4.0:
  - Fixes to initial realease to code logic including QGIS Plugin Store Compliance
  - PBN 15 NM and 30 NM targets included

--- a/Q_Pansopy/modules/pbn/_lnav_common.py
+++ b/Q_Pansopy/modules/pbn/_lnav_common.py
@@ -42,6 +42,12 @@ def _select_segment_features(iface, routing_layer, segment_type):
             level=Qgis.Critical,
         )
         return None
+    if routing_layer.fields().indexFromName('segment') == -1:
+        iface.messageBar().pushMessage(
+            "Routing layer is missing the required 'segment' field",
+            level=Qgis.Critical,
+        )
+        return None
     filtered = [f for f in selected if f.attribute("segment") == segment_type]
     if not filtered:
         iface.messageBar().pushMessage(

--- a/Q_Pansopy/modules/pbn/pbn_rnav1_arrival.py
+++ b/Q_Pansopy/modules/pbn/pbn_rnav1_arrival.py
@@ -72,6 +72,14 @@ def run_rnav1_arrival(iface, routing_layer, params=None):
             )
             return None
 
+        if routing_layer.fields().indexFromName('segment') == -1:
+            iface.messageBar().pushMessage(
+                "QPANSOPY",
+                "Routing layer is missing the required 'segment' field",
+                level=Qgis.Critical
+            )
+            return None
+
         arrival_features = [
             feat for feat in selected_features
             if feat.attribute('segment') == 'arrival'

--- a/tests/unit/test_pbn_modules.py
+++ b/tests/unit/test_pbn_modules.py
@@ -54,3 +54,52 @@ def test_lnav_common_select_segment_features():
     mod = importlib.import_module('Q_Pansopy.modules.pbn._lnav_common')
     assert hasattr(mod, '_select_segment_features')
     assert callable(mod._select_segment_features)
+
+
+class _FakeMessageBar:
+    def __init__(self):
+        self.messages = []
+
+    def pushMessage(self, *args, **kwargs):
+        self.messages.append((args, kwargs))
+
+
+class _FakeIface:
+    def __init__(self):
+        self._bar = _FakeMessageBar()
+
+    def messageBar(self):
+        return self._bar
+
+
+class _FakeFields:
+    def __init__(self, names):
+        self._names = names
+
+    def indexFromName(self, name):
+        return self._names.index(name) if name in self._names else -1
+
+
+class _FakeRoutingLayer:
+    def __init__(self, field_names, features):
+        self._fields = _FakeFields(field_names)
+        self._features = features
+
+    def fields(self):
+        return self._fields
+
+    def selectedFeatures(self):
+        return self._features
+
+
+def test_select_segment_features_missing_field_reports_clear_error():
+    mod = importlib.import_module('Q_Pansopy.modules.pbn._lnav_common')
+    iface = _FakeIface()
+    layer = _FakeRoutingLayer(field_names=['id', 'geom'], features=[object()])
+
+    result = mod._select_segment_features(iface, layer, 'initial')
+
+    assert result is None
+    assert iface.messageBar().messages, 'expected a message bar error to be pushed'
+    last_message_text = str(iface.messageBar().messages[-1])
+    assert 'segment' in last_message_text.lower()


### PR DESCRIPTION
# PR — LNAV tool silently fails when Routing layer lacks a "segment" field (Issue #168)

## Summary

- The LNAV tool (PBN toolbar) now shows a clear message-bar error — "Routing layer is missing
  the required 'segment' field" — when the Routing layer doesn't have the `segment` field it
  needs, instead of Calculate silently doing nothing.
- Fixes this for all five approach types that depend on the field: Initial, Intermediate,
  Missed, Final, and Arrival. SID is unaffected since it never reads this field.

## Root cause

`_select_segment_features()` (`Q_Pansopy/modules/pbn/_lnav_common.py`, used by Initial/
Intermediate/Missed/Final) and the inline duplicate in `pbn_rnav1_arrival.py` (Arrival) both
filter selected features with `f.attribute("segment") == segment_type`. When the Routing layer
has no `segment` field at all, `QgsFeature.attribute()` raises `KeyError('segment')` rather than
returning `None`. Each calculation module already wraps its body in a blanket
`try/except Exception` that caught this `KeyError` and turned it into a cryptic, transient
message-bar bubble reading just `"Error in initial approach: 'segment'"`, then returned `None` —
which the dockwidget's `calculate()` treats as "no result", adding nothing to its persistent log
panel. From the user's perspective, clicking Calculate did nothing.

## Implementation notes

### Guard at the true source
Both places that read the `segment` field now check for its existence first, mirroring their
own existing sibling validations ("no selection", "no matching segment"):
```python
# _lnav_common.py — _select_segment_features()
if routing_layer.fields().indexFromName('segment') == -1:
    iface.messageBar().pushMessage(
        "Routing layer is missing the required 'segment' field",
        level=Qgis.Critical,
    )
    return None
```
```python
# pbn_rnav1_arrival.py — inline duplicate, matching this file's own pushMessage signature
if routing_layer.fields().indexFromName('segment') == -1:
    iface.messageBar().pushMessage(
        "QPANSOPY",
        "Routing layer is missing the required 'segment' field",
        level=Qgis.Critical
    )
    return None
```
Every caller of `_select_segment_features` already handles a `None` return cleanly
(`if initial_features is None: return None`), so no other change was needed in
`lnav_initial_approach.py`, `lnav_intermediate_approach.py`, `lnav_missed_approach.py`, or
`lnav_final_approach.py`. `rnav_sid_missed.py` (SID) was left untouched — it never reads a
`segment` field, so it isn't part of this bug.

## Files Modified

| File | Change |
|---|---|
| `Q_Pansopy/modules/pbn/_lnav_common.py` | Add missing-`segment`-field guard to `_select_segment_features()` |
| `Q_Pansopy/modules/pbn/pbn_rnav1_arrival.py` | Add the same guard to its inline duplicate |
| `Q_Pansopy/metadata.txt` | One changelog bullet under Version 0.4.1 |
| `tests/unit/test_pbn_modules.py` | New behavioral test for the missing-field guard |
| `docs/plan-168.md` | Implementation plan |

## Test plan

- [x] `pytest tests/ -q` — no regressions, new test passes.
- [x] Flake8: 0 findings on the two changed module files (one pre-existing, unrelated finding
  in `tests/unit/test_pbn_modules.py:14` confirmed present on `main` before this branch).
- [ ] Select a Routing layer/feature(s) where the layer has no `segment` field; for each of
  Initial/Intermediate/Missed/Final/Arrival, click Calculate — a clear message-bar error naming
  the missing `segment` field appears.
- [ ] SID calculation still works normally on a layer without a `segment` field (unaffected).
- [ ] Existing happy-path behavior (layer with a valid `segment` field) is unchanged for all
  approach types.

## Related

Closes #168.
