### PR TITLE
LNAV tool should check for keywords in segment: add SID/departure (Issue #169)

### DIFF
--- a/Q_Pansopy/metadata.txt
+++ b/Q_Pansopy/metadata.txt
@@ -26,6 +26,7 @@ changelog=
  - Fix NDB/DME Tolerance tool not appearing in the CONV toolbar
  - Require exactly one selected feature per layer in VOR/DME and NDB/DME Tolerance tools
  - Add optional live DER marker (direction + CWY offset) preview to the OMNI SID tool
+ - Require 'segment' == 'departure' for LNAV SID and rename its output layer to 'PBN RNAV 1/2 Departure'
  Version 0.4.0:
  - Fixes to initial realease to code logic including QGIS Plugin Store Compliance
  - PBN 15 NM and 30 NM targets included

--- a/Q_Pansopy/modules/pbn/_lnav_common.py
+++ b/Q_Pansopy/modules/pbn/_lnav_common.py
@@ -42,6 +42,12 @@ def _select_segment_features(iface, routing_layer, segment_type):
             level=Qgis.Critical,
         )
         return None
+    if routing_layer.fields().indexFromName('segment') == -1:
+        iface.messageBar().pushMessage(
+            "Routing layer is missing the required 'segment' field",
+            level=Qgis.Critical,
+        )
+        return None
     filtered = [f for f in selected if f.attribute("segment") == segment_type]
     if not filtered:
         iface.messageBar().pushMessage(

--- a/Q_Pansopy/modules/pbn/rnav_sid_missed.py
+++ b/Q_Pansopy/modules/pbn/rnav_sid_missed.py
@@ -9,6 +9,8 @@ from qgis.PyQt.QtCore import QVariant
 import math
 import os
 
+from ._lnav_common import _select_segment_features
+
 # Compat for QGIS 3/4: QgsWkbTypes.LineGeometry → Qgis.GeometryType.Line
 try:
     _LINE_GEOMETRY = Qgis.GeometryType.Line  # QGIS 4+
@@ -21,11 +23,14 @@ except AttributeError:
 
 def run_rnav_sid_missed(iface, routing_layer, rnav_mode: str, op_mode: str,
                         export_kml: bool = False, output_dir: str | None = None):
-    """Generate RNAV1/2 SID (o Missed) usando la geometría legacy <15NM."""
+    """Generate RNAV1/2 SID (o Missed) usando la geometría legacy <15NM.
+
+    Requires the routing layer to have a ``segment`` field, with the selected
+    feature(s) tagged ``'departure'`` for the SID case.
+    """
     try:
-        selection = routing_layer.selectedFeatures()
-        if not selection:
-            iface.messageBar().pushMessage("QPANSOPY", "No features selected", level=Qgis.Critical)
+        selection = _select_segment_features(iface, routing_layer, 'departure')
+        if selection is None:
             return False
 
         geom = selection[0].geometry()
@@ -85,7 +90,7 @@ def run_rnav_sid_missed(iface, routing_layer, rnav_mode: str, op_mode: str,
             pts[f"m{a}"] = QgsPoint(end_point.x() + dist_x, end_point.y() + dist_y)
             a += 1
 
-        v_layer = QgsVectorLayer(f"PolygonZ?crs={map_srid}", "PBN RNAV 1/2", "memory")
+        v_layer = QgsVectorLayer(f"PolygonZ?crs={map_srid}", "PBN RNAV 1/2 Departure", "memory")
         myField = QgsField('Symbol', QVariant.String)
         v_layer.dataProvider().addAttributes([myField])
         v_layer.updateFields()

--- a/tests/unit/test_pbn_modules.py
+++ b/tests/unit/test_pbn_modules.py
@@ -54,3 +54,76 @@ def test_lnav_common_select_segment_features():
     mod = importlib.import_module('Q_Pansopy.modules.pbn._lnav_common')
     assert hasattr(mod, '_select_segment_features')
     assert callable(mod._select_segment_features)
+
+
+class _FakeMessageBar:
+    def __init__(self):
+        self.messages = []
+
+    def pushMessage(self, *args, **kwargs):
+        self.messages.append((args, kwargs))
+
+
+class _FakeIface:
+    def __init__(self):
+        self._bar = _FakeMessageBar()
+
+    def messageBar(self):
+        return self._bar
+
+
+class _FakeFields:
+    def __init__(self, names):
+        self._names = names
+
+    def indexFromName(self, name):
+        return self._names.index(name) if name in self._names else -1
+
+
+class _FakeFeature:
+    def __init__(self, segment_value):
+        self._segment_value = segment_value
+
+    def attribute(self, name):
+        if name != 'segment':
+            raise KeyError(name)
+        return self._segment_value
+
+
+class _FakeRoutingLayer:
+    def __init__(self, field_names, features):
+        self._fields = _FakeFields(field_names)
+        self._features = features
+
+    def fields(self):
+        return self._fields
+
+    def selectedFeatures(self):
+        return self._features
+
+
+def test_select_segment_features_missing_field_reports_clear_error():
+    mod = importlib.import_module('Q_Pansopy.modules.pbn._lnav_common')
+    iface = _FakeIface()
+    layer = _FakeRoutingLayer(field_names=['id', 'geom'], features=[_FakeFeature('initial')])
+
+    result = mod._select_segment_features(iface, layer, 'initial')
+
+    assert result is None
+    assert iface.messageBar().messages, 'expected a message bar error to be pushed'
+    last_message_text = str(iface.messageBar().messages[-1])
+    assert 'segment' in last_message_text.lower()
+
+
+def test_select_segment_features_filters_by_departure_keyword():
+    mod = importlib.import_module('Q_Pansopy.modules.pbn._lnav_common')
+    iface = _FakeIface()
+    departure_feature = _FakeFeature('departure')
+    layer = _FakeRoutingLayer(
+        field_names=['id', 'segment'],
+        features=[_FakeFeature('initial'), departure_feature, _FakeFeature('final')],
+    )
+
+    result = mod._select_segment_features(iface, layer, 'departure')
+
+    assert result == [departure_feature]


### PR DESCRIPTION
# PR — LNAV tool should check for keywords in segment: add SID/departure (Issue #169)

## Summary

- The SID (RNAV1/RNAV2) path of the LNAV tool now requires the selected routing feature(s) to
  have `segment == 'departure'`, exactly like every other approach type already requires its own
  keyword (`'initial'`, `'intermediate'`, `'final'`, `'missed'`, `'arrival'`).
- The SID module's output layer is renamed from `"PBN RNAV 1/2"` to `"PBN RNAV 1/2 Departure"`,
  matching the naming convention already used by the sibling Arrival module
  (`"PBN RNAV 1/2 Arrival"`).

## Root cause

`run_rnav_sid_missed()` (`Q_Pansopy/modules/pbn/rnav_sid_missed.py`) never used the shared
`_select_segment_features()` helper that every other approach type relies on — it simply took
`routing_layer.selectedFeatures()[0]` unconditionally, with no `segment` field check. So SID was
the one approach type not participating in the segment-keyword system the rest of the LNAV tool
already uses.

## Implementation notes

### Reuse the existing shared helper
```python
from ._lnav_common import _select_segment_features
...
selection = _select_segment_features(iface, routing_layer, 'departure')
if selection is None:
    return False
```
This is the same helper already used by Initial/Intermediate/Missed/Final, so SID now gets
identical, already-established behavior for free: clear errors for "no selection", "no matching
segment", and (see below) a missing `segment` field — plus consistency with the rest of the
tool rather than a bespoke check.

### Missing-`segment`-field guard
`_select_segment_features()` in `_lnav_common.py` now also checks
`routing_layer.fields().indexFromName('segment') == -1` and reports a clear error rather than
letting a `KeyError` propagate — the same fix as issue #168, re-added here since this branch is
independent of that (not yet merged) branch and SID now depends on this helper too. The two
branches touch the same lines identically, so they'll merge cleanly regardless of order.

### Output layer rename
```python
v_layer = QgsVectorLayer(f"PolygonZ?crs={map_srid}", "PBN RNAV 1/2 Departure", "memory")
```

### Scope
`rnav1_2_missed_less_15nm.py` (a legacy standalone script with the same old output layer name)
is intentionally untouched — it isn't referenced anywhere in `qpansopy.py` or any dockwidget.

## Files Modified

| File | Change |
|---|---|
| `Q_Pansopy/modules/pbn/_lnav_common.py` | Add missing-`segment`-field guard to `_select_segment_features()` |
| `Q_Pansopy/modules/pbn/rnav_sid_missed.py` | Filter selection by `segment == 'departure'`; rename output layer |
| `Q_Pansopy/metadata.txt` | One changelog bullet under Version 0.4.1 |
| `tests/unit/test_pbn_modules.py` | New tests for the missing-field guard and `'departure'` keyword filtering |
| `docs/plan-169.md` | Implementation plan |

## Test plan

- [x] `pytest tests/ -q` — no regressions, new tests pass.
- [x] Flake8: 0 findings on the two changed module files.
- [ ] Select a routing feature tagged `segment == 'departure'` and run SID — output layer is
  named "PBN RNAV 1/2 Departure"; geometry matches prior behavior.
- [ ] Select a feature NOT tagged `'departure'` (or a layer missing the `segment` field
  entirely) and run SID — a clear message-bar error appears instead of silently using the wrong
  feature.
- [ ] Other approach types (Initial/Intermediate/Missed/Final/Arrival) are unaffected.

## Related

Closes #169.
