### PR TITLE
OMNI SID DER marker: connector line + plain triangle, CWY=0 case (Issue #167 follow-up)

### DIFF
--- a/Q_Pansopy/dockwidgets/departures/qpansopy_omnidirectional_dockwidget.py
+++ b/Q_Pansopy/dockwidgets/departures/qpansopy_omnidirectional_dockwidget.py
@@ -33,12 +33,10 @@ from ...qt_compat import (
     preseed_active_layer, Qgis_GeomType_Line, Qgis_GeomType_Polygon,
 )
 
-# DER marker arrow dimensions in screen pixels (converted to map units via
+# DER marker triangle dimensions in screen pixels (converted to map units via
 # mapUnitsPerPixel so the marker stays a constant, visible size at any zoom level)
-_DER_MARKER_SHAFT_LENGTH_PX = 40
-_DER_MARKER_SHAFT_HALF_WIDTH_PX = 4
-_DER_MARKER_HEAD_LENGTH_PX = 16
-_DER_MARKER_HEAD_HALF_WIDTH_PX = 12
+_DER_MARKER_LENGTH_PX = 24
+_DER_MARKER_HALF_WIDTH_PX = 12
 
 
 # Use __file__ to get the current script path
@@ -85,11 +83,15 @@ class QPANSOPYOmnidirectionalDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         self.cwyDistanceSpinBox.setValue(0)
         self.cwyDistanceUnitCombo.setCurrentText('m')
 
-        # Live DER marker preview (off by default)
+        # Live DER marker preview (off by default): a triangle at the used DER (DER+CWY)
+        # point, plus a connector line back to the actual runway edge when CWY > 0.
         self._der_marker_band = QgsRubberBand(iface.mapCanvas(), Qgis_GeomType_Polygon)
         self._der_marker_band.setColor(QColor(0, 170, 0, 120))
         self._der_marker_band.setStrokeColor(QColor(0, 120, 0, 220))
         self._der_marker_band.setWidth(1)
+        self._der_line_band = QgsRubberBand(iface.mapCanvas(), Qgis_GeomType_Line)
+        self._der_line_band.setColor(QColor(0, 120, 0, 220))
+        self._der_line_band.setWidth(2)
         self._connected_runway_layer = None
 
         self.runwayLayerComboBox.layerChanged.connect(self._on_runway_layer_changed)
@@ -148,6 +150,8 @@ class QPANSOPYOmnidirectionalDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
     def _clear_der_marker(self):
         if self._der_marker_band:
             self._der_marker_band.reset(Qgis_GeomType_Polygon)
+        if self._der_line_band:
+            self._der_line_band.reset(Qgis_GeomType_Line)
 
     def _update_der_marker(self, *args):
         self._clear_der_marker()
@@ -178,32 +182,28 @@ class QPANSOPYOmnidirectionalDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
                 der_point = QgsPoint(runway_geometry[1])
 
             runway_azimuth = threshold_point.azimuth(der_point)
-            der_cwy_point = der_point.project(self.cwyDistanceSpinBox.value(), runway_azimuth)
+            cwy_distance = self.cwyDistanceSpinBox.value()
+            der_cwy_point = der_point.project(cwy_distance, runway_azimuth)
 
-            # Size the marker in screen pixels so it stays visible at any zoom level
+            # Connector line from the runway edge used as DER to the used DER (DER+CWY).
+            # Only meaningful when there's an actual CWY offset to show.
+            if cwy_distance > 0:
+                line = QgsGeometry(QgsLineString([der_point, der_cwy_point]))
+                self._der_line_band.setToGeometry(line, None)
+
+            # Triangle marker, always shown: tip at the used DER, base trailing back
+            # toward the runway. Size in screen pixels so it stays visible at any zoom.
             mupp = self.iface.mapCanvas().mapUnitsPerPixel()
-            shaft_length = _DER_MARKER_SHAFT_LENGTH_PX * mupp
-            shaft_half_width = _DER_MARKER_SHAFT_HALF_WIDTH_PX * mupp
-            head_length = _DER_MARKER_HEAD_LENGTH_PX * mupp
-            head_half_width = _DER_MARKER_HEAD_HALF_WIDTH_PX * mupp
+            marker_length = _DER_MARKER_LENGTH_PX * mupp
+            marker_half_width = _DER_MARKER_HALF_WIDTH_PX * mupp
 
-            # Arrow tip sits at the DER+CWY point, shaft trails back toward the threshold
             back_azimuth = runway_azimuth + 180
-            back_point = der_cwy_point.project(shaft_length + head_length, back_azimuth)
-            head_base_point = der_cwy_point.project(head_length, back_azimuth)
+            base_center = der_cwy_point.project(marker_length, back_azimuth)
+            base_left = base_center.project(marker_half_width, runway_azimuth - 90)
+            base_right = base_center.project(marker_half_width, runway_azimuth + 90)
 
-            back_left = back_point.project(shaft_half_width, runway_azimuth - 90)
-            back_right = back_point.project(shaft_half_width, runway_azimuth + 90)
-            shaft_head_left = head_base_point.project(shaft_half_width, runway_azimuth - 90)
-            shaft_head_right = head_base_point.project(shaft_half_width, runway_azimuth + 90)
-            head_left = head_base_point.project(head_half_width, runway_azimuth - 90)
-            head_right = head_base_point.project(head_half_width, runway_azimuth + 90)
-
-            arrow = QgsGeometry(QgsPolygon(QgsLineString([
-                back_left, shaft_head_left, head_left, der_cwy_point,
-                head_right, shaft_head_right, back_right,
-            ])))
-            self._der_marker_band.setToGeometry(arrow, None)
+            triangle = QgsGeometry(QgsPolygon(QgsLineString([der_cwy_point, base_left, base_right])))
+            self._der_marker_band.setToGeometry(triangle, None)
         except Exception:
             pass
 

--- a/Q_Pansopy/metadata.txt
+++ b/Q_Pansopy/metadata.txt
@@ -28,6 +28,7 @@ changelog=
  - Add optional live DER marker (direction + CWY offset) preview to the OMNI SID tool
  - Show a clear error when the LNAV Routing layer is missing the required 'segment' field
  - Require 'segment' == 'departure' for LNAV SID and rename its output layer to 'PBN RNAV 1/2 Departure'
+ - OMNI SID DER marker: plain green triangle plus a connector line to the runway edge when CWY > 0
  Version 0.4.0:
  - Fixes to initial realease to code logic including QGIS Plugin Store Compliance
  - PBN 15 NM and 30 NM targets included


### PR DESCRIPTION
# PR — OMNI SID DER marker: connector line + plain triangle, CWY=0 case (Issue #167 follow-up)

## Summary

- The OMNI SID DER marker is now two parts instead of one arrow shape: a plain green triangle
  at the used DER (DER+CWY) point, and a separate green connector line from the actual runway
  edge to that point — drawn only when CWY > 0.
- When CWY = 0, only the triangle is shown (no degenerate zero-length line/arrow), matching the
  reporter's "green triangle for the case CWY = 0" request.

## Root cause / motivation

Issue #167 (PR #180) originally drew a single shaft-and-arrowhead polygon at the DER+CWY point.
When CWY = 0 the shaft trailing back from the tip had effectively zero length, so the "arrow"
didn't read correctly for that case. The reporter asked for a connecting line from the runway
edge to the used DER, with a plain marker (not an arrow) at the tip — and confirmed the marker
itself should just be a simple green triangle.

## Implementation notes

### Two rubber bands instead of one
```python
self._der_marker_band = QgsRubberBand(iface.mapCanvas(), Qgis_GeomType_Polygon)  # triangle
self._der_line_band = QgsRubberBand(iface.mapCanvas(), Qgis_GeomType_Line)        # connector
```

### Connector line, only when there's a real offset
```python
if cwy_distance > 0:
    line = QgsGeometry(QgsLineString([der_point, der_cwy_point]))
    self._der_line_band.setToGeometry(line, None)
```

### Plain triangle, always drawn
```python
back_azimuth = runway_azimuth + 180
base_center = der_cwy_point.project(marker_length, back_azimuth)
base_left = base_center.project(marker_half_width, runway_azimuth - 90)
base_right = base_center.project(marker_half_width, runway_azimuth + 90)
triangle = QgsGeometry(QgsPolygon(QgsLineString([der_cwy_point, base_left, base_right])))
```
Tip sits exactly at the used DER (`der_cwy_point`); the base trails back toward the runway.
Sizing is unchanged from the prior implementation — computed via
`mapCanvas().mapUnitsPerPixel()` so it stays a constant, visible size at any zoom level.

### Scope
No changes to the checkbox, signal wiring, calculation module, or `.ui` file — this is a pure
geometry/visual change inside `_update_der_marker()`.

## Files Modified

| File | Change |
|---|---|
| `Q_Pansopy/dockwidgets/departures/qpansopy_omnidirectional_dockwidget.py` | Split arrow into triangle + conditional connector line |
| `Q_Pansopy/metadata.txt` | One changelog bullet under Version 0.4.1 |
| `docs/plan-167-followup.md` | Implementation plan |

## Test plan

- [x] `pytest tests/ -q` — no regressions.
- [x] Flake8: 0 findings on the changed file.
- [ ] CWY = 0: only the green triangle appears at the runway edge, tip pointing in the
  direction of flight; no connecting line.
- [ ] CWY > 0: a green line runs from the runway edge to the offset DER point, ending in the
  triangle whose tip touches the used-DER point.
- [ ] Toggling Start→End/End→Start and changing CWY live-update both the line and the triangle;
  zoom-independent sizing and checkbox on/off behavior are unchanged.

## Related

Follow-up to #167.
