### PR TITLE
OMNI SID store area distances in the attribute table (Issue #182)

### DIFF
--- a/Q_Pansopy/metadata.txt
+++ b/Q_Pansopy/metadata.txt
@@ -29,6 +29,7 @@ changelog=
  - Show a clear error when the LNAV Routing layer is missing the required 'segment' field
  - Require 'segment' == 'departure' for LNAV SID and rename its output layer to 'PBN RNAV 1/2 Departure'
  - OMNI SID DER marker: plain green triangle plus a connector line to the runway edge when CWY > 0
+ - Store Area 1/2/3 distances (meters, 4 decimals) in the OMNI SID output attribute table
  Version 0.4.0:
  - Fixes to initial realease to code logic including QGIS Plugin Store Compliance
  - PBN 15 NM and 30 NM targets included

--- a/Q_Pansopy/modules/departures/omnidirectional_sid.py
+++ b/Q_Pansopy/modules/departures/omnidirectional_sid.py
@@ -202,25 +202,28 @@ def create_projected_point(point_name, origin_point, distance, azimuth, elevatio
     points_dict[point_name] = projected_point
 
 
-def create_polygon_surface(surface_name, vertices, layer, surfaces_dict):
+def create_polygon_surface(surface_name, vertices, layer, surfaces_dict, distance_m=None):
     """
     Create a 3D polygon surface and add it to a layer.
-    
+
     Creates a PolygonZ feature from a list of vertices and adds it
     to the specified layer. Also stores the geometry in a dictionary
     for later geometric operations (e.g., difference).
-    
+
     Args:
         surface_name (str): Name/identifier for the surface area.
         vertices (list): List of QgsPoint vertices forming the polygon.
         layer (QgsVectorLayer): Layer to add the feature to.
         surfaces_dict (dict): Dictionary to store the geometry for later use.
+        distance_m (float, optional): Area distance in meters, stored rounded
+            to 4 decimal places in the 'distance_m' field. None (NULL) when
+            not applicable to this surface.
     """
     provider = layer.dataProvider()
     feature = QgsFeature()
     polygon = QgsPolygon(QgsLineString(vertices), rings=[])
     feature.setGeometry(polygon)
-    feature.setAttributes([surface_name])
+    feature.setAttributes([surface_name, round(distance_m, 4) if distance_m is not None else None])
     provider.addFeatures([feature])
     surfaces_dict[surface_name] = feature.geometry()
 
@@ -536,7 +539,10 @@ def run_omnidirectional_sid(iface, runway_layer, params, log_callback=None):
         layer_name,
         "memory"
     )
-    surfaces_layer.dataProvider().addAttributes([QgsField('omni_area', QVariant.String)])
+    surfaces_layer.dataProvider().addAttributes([
+        QgsField('omni_area', QVariant.String),
+        QgsField('distance_m', QVariant.Double, 'double', 10, 4)
+    ])
     surfaces_layer.updateFields()
 
     surfaces_geometries = {}
@@ -553,7 +559,8 @@ def run_omnidirectional_sid(iface, runway_layer, params, log_callback=None):
             construction_points['point_1_center']
         ],
         surfaces_layer,
-        surfaces_geometries
+        surfaces_geometries,
+        distance_area_1
     )
 
     # Create Area 2 polygon
@@ -568,7 +575,8 @@ def run_omnidirectional_sid(iface, runway_layer, params, log_callback=None):
             construction_points['point_2_center']
         ],
         surfaces_layer,
-        surfaces_geometries
+        surfaces_geometries,
+        distance_area_2
     )
 
     # Create Before DER area if enabled
@@ -607,7 +615,7 @@ def run_omnidirectional_sid(iface, runway_layer, params, log_callback=None):
     provider = surfaces_layer.dataProvider()
     area_3_feature = QgsFeature()
     area_3_feature.setGeometry(area_3_geometry)
-    area_3_feature.setAttributes(['Area 3'])
+    area_3_feature.setAttributes(['Area 3', round(distance_area_3, 4)])
     provider.addFeatures([area_3_feature])
 
     surfaces_layer.updateExtents()


### PR DESCRIPTION
# PR — OMNI SID store area distances in the attribute table (Issue #182)

## Summary

- The OMNI SID output polygon layer now stores each area's distance in a `distance_m` field
  (meters, rounded to 4 decimal places), for use in later calculations.
- Area 1 and Area 2 store their respective computed distances; Area 3 stores the radius of its
  circle; the optional "Before DER" area (not mentioned in the issue) stores NULL rather than a
  fabricated value.
- No new layers — this only adds a column to the existing output layer's attribute table.
<img width="223" height="218" alt="{BC054D04-A0DD-4425-9BF7-8CD026C79404}" src="https://github.com/user-attachments/assets/b6ac2ec5-3672-4771-8bf8-60546665335c" />

## Root cause / motivation

`surfaces_layer` only had an `'omni_area'` (String) field identifying which area a feature is;
the actual distance values (`distance_area_1`, `distance_area_2`, `distance_area_3`), already
computed by the module, were never persisted anywhere the user or downstream calculations could
read them.

## Implementation notes

### New field, existing layer
```python
surfaces_layer.dataProvider().addAttributes([
    QgsField('omni_area', QVariant.String),
    QgsField('distance_m', QVariant.Double, 'double', 10, 4)
])
```
Matches the existing `point_filter.py` precedent for a 4-arg `QgsField(name, type, typeName,
len, prec)` fixed-precision distance column (`prec=4`, per "4 decimal places").

### `create_polygon_surface()` gains an optional distance parameter
```python
def create_polygon_surface(surface_name, vertices, layer, surfaces_dict, distance_m=None):
    ...
    feature.setAttributes([surface_name, round(distance_m, 4) if distance_m is not None else None])
```
Area 1 and Area 2 now pass `distance_area_1`/`distance_area_2`; the "Before DER" call is
unchanged (still omits the argument), so it stores NULL rather than inventing a value the issue
never asked for.

### Area 3 (built separately as a buffer-difference geometry)
```python
area_3_feature.setAttributes(['Area 3', round(distance_area_3, 4)])
```
`distance_area_3` is already the circle's radius (it's passed directly into
`QgsGeometry.fromPointXY(buffer_center).buffer(distance_area_3, BUFFER_SEGMENTS)`), confirming
it's exactly what the issue means by "Area 3 is the radius of the circle".

## Files Modified

| File | Change |
|---|---|
| `Q_Pansopy/modules/departures/omnidirectional_sid.py` | Add `distance_m` field; store rounded distances on Area 1/2/3 features |
| `Q_Pansopy/metadata.txt` | One changelog bullet under Version 0.4.1 |
| `docs/plan-182.md` | Implementation plan |

## Test plan

- [x] `pytest tests/ -q` — no regressions.
- [x] Flake8: 0 findings on the changed file.
- [ ] Run OMNI SID, open the output layer's attribute table — Area 1/Area 2 show `distance_m`
  matching the logged distance values, rounded to 4 decimals.
- [ ] Area 3 shows the circle radius in `distance_m`.
- [ ] With "Allow turns before DER" checked, the "Before DER" feature's `distance_m` is NULL.

## Related

Closes #182.
