### PR TITLE
Fix Wind Spiral ISA calculator Qt6 crash (Issue #172)

### DIFF
--- a/Q_Pansopy/dockwidgets/utilities/qpansopy_wind_spiral_dockwidget.py
+++ b/Q_Pansopy/dockwidgets/utilities/qpansopy_wind_spiral_dockwidget.py
@@ -463,7 +463,7 @@ class QPANSOPYWindSpiralDockWidgetBase(QtWidgets.QDockWidget, FORM_CLASS):
         """Show ISA Calculator dialog and apply the result to isaVarLineEdit"""
         from ...isa_calculator_dialog import ISACalculatorDialog
         dlg = ISACalculatorDialog(self)
-        if dlg.exec_():
+        if dlg.exec():
             isa_variation = dlg.get_isa_variation()
             if isa_variation is not None:
                 self.isaVarLineEdit.setText(f"{isa_variation:.5f}")

--- a/Q_Pansopy/isa_calculator_dialog.py
+++ b/Q_Pansopy/isa_calculator_dialog.py
@@ -26,6 +26,7 @@ from qgis.PyQt.QtWidgets import (QDialog, QVBoxLayout, QHBoxLayout, QFormLayout,
                                  QDialogButtonBox, QMessageBox, QGroupBox, QWidget)
 from qgis.PyQt.QtCore import QRegularExpression
 from qgis.PyQt.QtGui import QRegularExpressionValidator
+from .qt_compat import QDialogButtonBox_Ok, QDialogButtonBox_Cancel
 
 
 class ISACalculatorDialog(QDialog):
@@ -101,12 +102,12 @@ class ISACalculatorDialog(QDialog):
         layout.addWidget(calc_group)
 
         # Dialog buttons
-        button_box = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        button_box = QDialogButtonBox(QDialogButtonBox_Ok | QDialogButtonBox_Cancel)
         button_box.accepted.connect(self.accept_calculation)
         button_box.rejected.connect(self.reject)
 
         # Initially disable OK button
-        self.ok_button = button_box.button(QDialogButtonBox.Ok)
+        self.ok_button = button_box.button(QDialogButtonBox_Ok)
         self.ok_button.setEnabled(False)
 
         layout.addWidget(button_box)

--- a/Q_Pansopy/metadata.txt
+++ b/Q_Pansopy/metadata.txt
@@ -31,6 +31,7 @@ changelog=
  - OMNI SID DER marker: plain green triangle plus a connector line to the runway edge when CWY > 0
  - Store Area 1/2/3 distances (meters, 4 decimals) in the OMNI SID output attribute table
  - Combine VOR/DME and NDB/DME tolerance tools under one CONV toolbar dropdown icon and add LOC/DME Tolerance (2.4° default)
+ - Fix Wind Spiral ISA calculator and Settings dialog crashing on QGIS 4 / Qt6 (QDialogButtonBox scoped enum, dlg.exec_() removed in PyQt6)
  Version 0.4.0:
  - Fixes to initial realease to code logic including QGIS Plugin Store Compliance
  - PBN 15 NM and 30 NM targets included

--- a/Q_Pansopy/qpansopy.py
+++ b/Q_Pansopy/qpansopy.py
@@ -1313,7 +1313,7 @@ class Qpansopy:
             "<br><a href='https://github.com/FLYGHT7/qpansopy'>https://github.com/FLYGHT7/qpansopy</a>")
         github_label.setOpenExternalLinks(True)
         layout.addWidget(github_label)
-        dlg.exec_()
+        dlg.exec()
 
     def show_settings_dialog(self):
         """
@@ -1332,7 +1332,7 @@ class Qpansopy:
         """
         # Use None as parent to avoid QWidget errors
         dlg = SettingsDialog(None, self.settings)
-        if dlg.exec_():
+        if dlg.exec():
             vals = dlg.get_values()
             self.settings.setValue("qpansopy/enable_kml", vals["enable_kml"])
             self.settings.setValue("qpansopy/show_log", vals["show_log"])

--- a/Q_Pansopy/qt_compat.py
+++ b/Q_Pansopy/qt_compat.py
@@ -33,7 +33,7 @@ try:
         QPushButton, QGroupBox, QFileDialog, QMessageBox,
         QHBoxLayout, QVBoxLayout, QFormLayout,
         QCheckBox, QProgressBar, QTextEdit, QScrollArea,
-        QFrame, QSizePolicy, QLayout,
+        QFrame, QSizePolicy, QLayout, QDialogButtonBox,
     )
     from qgis.PyQt.QtCore import (  # noqa: F401
         Qt, QEvent, QVariant, pyqtSignal, QRegularExpression,
@@ -54,7 +54,7 @@ except ImportError:
             QPushButton, QGroupBox, QFileDialog, QMessageBox,
             QHBoxLayout, QVBoxLayout, QFormLayout,
             QCheckBox, QProgressBar, QTextEdit, QScrollArea,
-            QFrame, QSizePolicy, QLayout,
+            QFrame, QSizePolicy, QLayout, QDialogButtonBox,
         )
         from PyQt6.QtCore import (  # noqa: F401
             Qt, QEvent, pyqtSignal, QRegularExpression,
@@ -87,7 +87,7 @@ except ImportError:
             QPushButton, QGroupBox, QFileDialog, QMessageBox,
             QHBoxLayout, QVBoxLayout, QFormLayout,
             QCheckBox, QProgressBar, QTextEdit, QScrollArea,
-            QFrame, QSizePolicy, QLayout,
+            QFrame, QSizePolicy, QLayout, QDialogButtonBox,
         )
         from PyQt5.QtCore import (  # noqa: F401
             Qt, QEvent, QVariant, pyqtSignal, QRegularExpression,
@@ -416,6 +416,14 @@ except AttributeError:
     QToolButton_InstantPopup = _QToolButton.InstantPopup            # type: ignore[attr-defined]
     QToolButton_MenuButtonPopup = _QToolButton.MenuButtonPopup      # type: ignore[attr-defined]
     QToolButton_DelayedPopup = _QToolButton.DelayedPopup            # type: ignore[attr-defined]
+
+try:
+    _dbb = QDialogButtonBox.StandardButton  # Qt6 scoped enum namespace
+    QDialogButtonBox_Ok = _dbb.Ok
+    QDialogButtonBox_Cancel = _dbb.Cancel
+except AttributeError:
+    QDialogButtonBox_Ok = QDialogButtonBox.Ok          # type: ignore[attr-defined]
+    QDialogButtonBox_Cancel = QDialogButtonBox.Cancel  # type: ignore[attr-defined]
 
 try:
     _lwm = QTextEdit.LineWrapMode  # Qt6 scoped enum namespace

--- a/Q_Pansopy/settings_dialog.py
+++ b/Q_Pansopy/settings_dialog.py
@@ -1,5 +1,5 @@
 from qgis.PyQt import QtWidgets, QtGui
-from .qt_compat import Qt_AlignVCenter
+from .qt_compat import Qt_AlignVCenter, QDialogButtonBox_Ok, QDialogButtonBox_Cancel
 import os
 
 
@@ -38,7 +38,7 @@ class SettingsDialog(QtWidgets.QDialog):
         layout.addWidget(self.log_checkbox)
 
         # Buttons
-        btn_box = QtWidgets.QDialogButtonBox(QtWidgets.QDialogButtonBox.Ok | QtWidgets.QDialogButtonBox.Cancel)
+        btn_box = QtWidgets.QDialogButtonBox(QDialogButtonBox_Ok | QDialogButtonBox_Cancel)
         btn_box.accepted.connect(self.accept)
         btn_box.rejected.connect(self.reject)
         layout.addWidget(btn_box)


### PR DESCRIPTION
# PR — Fix Wind Spiral ISA calculator Qt6 crash (Issue #172)

## Summary

- Fixed a crash opening the ISA calculator dialog from the Wind Spiral tool on QGIS 4 / Qt6:
  `AttributeError: type object 'QDialogButtonBox' has no attribute 'Ok'`.
- Fixed the same latent bug in the Settings dialog (QPANSOPY menu → Settings), which used the
  identical unscoped-enum pattern and would have crashed the same way.
- Fixed a second, follow-up Qt6 crash surfaced once the dialog actually opened:
  `AttributeError: 'ISACalculatorDialog' object has no attribute 'exec_'` — PyQt6 dropped the
  Python-2-era `.exec_()` alias. Also fixed the same call in the plugin's About and Settings
  dialogs (`qpansopy.py`), which would have crashed identically.

## Root cause / motivation

Qt6/PyQt6 scopes enums under a nested namespace (`QDialogButtonBox.StandardButton.Ok`) while
Qt5/PyQt5 exposes them unscoped (`QDialogButtonBox.Ok`). `Q_Pansopy/isa_calculator_dialog.py`
and `Q_Pansopy/settings_dialog.py` both used the unscoped form directly, bypassing this
project's `Q_Pansopy/qt_compat.py` shim — which already handles this exact class of bug for
many other Qt enums (`QToolButton.ToolButtonPopupMode`, `QSizePolicy.Policy`, `QFrame.Shape`,
etc.) but didn't yet have an entry for `QDialogButtonBox`.

## Implementation notes

`Q_Pansopy/qt_compat.py` gained a `QDialogButtonBox` import (all three backend branches) and a
compat block following the existing pattern:
```python
try:
    _dbb = QDialogButtonBox.StandardButton  # Qt6 scoped enum namespace
    QDialogButtonBox_Ok = _dbb.Ok
    QDialogButtonBox_Cancel = _dbb.Cancel
except AttributeError:
    QDialogButtonBox_Ok = QDialogButtonBox.Ok          # Qt5 unscoped
    QDialogButtonBox_Cancel = QDialogButtonBox.Cancel
```
`isa_calculator_dialog.py` and `settings_dialog.py` now import `QDialogButtonBox_Ok` /
`QDialogButtonBox_Cancel` from `qt_compat` and use them instead of the raw enum.

Separately, `.exec_()` — a Python-2-compat alias PyQt5 kept around — no longer exists in PyQt6;
only `.exec()` remains. `.exec()` has always worked in Python 3 on both bindings (the trailing
underscore was only ever needed to dodge Python 2's `exec` statement), so this needed no compat
shim — just a straight rename at all three call sites.

## Files Modified

| File | Change |
|---|---|
| `Q_Pansopy/qt_compat.py` | Add `QDialogButtonBox` import + `QDialogButtonBox_Ok`/`QDialogButtonBox_Cancel` compat constants |
| `Q_Pansopy/isa_calculator_dialog.py` | Use compat constants instead of unscoped `QDialogButtonBox.Ok`/`.Cancel` |
| `Q_Pansopy/settings_dialog.py` | Use compat constants instead of unscoped `QDialogButtonBox.Ok`/`.Cancel` |
| `Q_Pansopy/dockwidgets/utilities/qpansopy_wind_spiral_dockwidget.py` | `dlg.exec_()` → `dlg.exec()` |
| `Q_Pansopy/qpansopy.py` | `dlg.exec_()` → `dlg.exec()` (About dialog, Settings dialog) |
| `Q_Pansopy/metadata.txt` | One changelog bullet under Version 0.4.1 |
| `docs/plan-172.md` | Implementation plan |

## Test plan

- [x] `pytest tests/ -q` — no regressions.
- [x] Flake8: 0 findings on all changed files.
- [x] QGIS 4: Wind Spiral tool → ISA calculator button opens the dialog without error; Ok is
  disabled until a calculation runs, then enables; Cancel/Ok both work.
- [x] QGIS 4: Settings dialog opens without error; Ok/Cancel both work.

## Related

Closes #172.
