### PR TITLE
ISA Calculator UI follow-up fixes (Issue #172)

### DIFF
--- a/Q_Pansopy/dockwidgets/base_dockwidget.py
+++ b/Q_Pansopy/dockwidgets/base_dockwidget.py
@@ -2,7 +2,7 @@ import pathlib
 from qgis.PyQt import QtWidgets
 
 
-def _load_base_qss() -> str:
+def load_base_qss() -> str:
     """Return the content of dockwidget_base.qss, empty string on error."""
     qss_path = pathlib.Path(__file__).parent.parent / "styles" / "dockwidget_base.qss"
     try:
@@ -20,7 +20,7 @@ class BasePansopyDockWidget(QtWidgets.QDockWidget):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.setStyleSheet(_load_base_qss())
+        self.setStyleSheet(load_base_qss())
 
     # ------------------------------------------------------------------ #
     # Log                                                                 #

--- a/Q_Pansopy/dockwidgets/utilities/qpansopy_wind_spiral_dockwidget.py
+++ b/Q_Pansopy/dockwidgets/utilities/qpansopy_wind_spiral_dockwidget.py
@@ -130,7 +130,7 @@ class QPANSOPYWindSpiralDockWidgetBase(QtWidgets.QDockWidget, FORM_CLASS):
         # ISA Variation LineEdit - same size as other fields
         self.isaVarLineEdit = QtWidgets.QLineEdit(self)
         self.isaVarLineEdit.setValidator(isa_validator)
-        self.isaVarLineEdit.setText("0.00000")
+        self.isaVarLineEdit.setText("15.00000")
         self.isaVarLineEdit.textChanged.connect(
             lambda text: self.handle_isa_manual_change(text))
         self.isaVarLineEdit.setMinimumHeight(28)

--- a/Q_Pansopy/isa_calculator_dialog.py
+++ b/Q_Pansopy/isa_calculator_dialog.py
@@ -23,10 +23,11 @@ Procedure Analysis and Obstacle Protection Surfaces - ISA Calculator
 
 from qgis.PyQt.QtWidgets import (QDialog, QVBoxLayout, QHBoxLayout, QFormLayout,
                                  QLineEdit, QComboBox, QPushButton, QLabel,
-                                 QDialogButtonBox, QMessageBox, QGroupBox, QWidget)
+                                 QMessageBox, QGroupBox, QWidget)
 from qgis.PyQt.QtCore import QRegularExpression
 from qgis.PyQt.QtGui import QRegularExpressionValidator
-from .qt_compat import QDialogButtonBox_Ok, QDialogButtonBox_Cancel
+from .qt_compat import Qt_AlignRight, Qt_AlignVCenter
+from .dockwidgets.base_dockwidget import load_base_qss
 
 
 class ISACalculatorDialog(QDialog):
@@ -36,6 +37,7 @@ class ISACalculatorDialog(QDialog):
         super().__init__(parent)
         self.setWindowTitle("ISA Calculator")
         self.setFixedSize(400, 300)
+        self.setStyleSheet(load_base_qss())
 
         # Result values
         self.isa_variation = None
@@ -50,6 +52,9 @@ class ISACalculatorDialog(QDialog):
         # Input Group
         input_group = QGroupBox("Input Parameters")
         input_layout = QFormLayout(input_group)
+        input_layout.setVerticalSpacing(12)
+        input_layout.setHorizontalSpacing(10)
+        input_layout.setLabelAlignment(Qt_AlignRight | Qt_AlignVCenter)
 
         # Create validator for numeric inputs
         regex = QRegularExpression(r"[-+]?[0-9]*\.?[0-9]+")
@@ -57,6 +62,8 @@ class ISACalculatorDialog(QDialog):
 
         # Aerodrome Elevation
         elev_container = QHBoxLayout()
+        elev_container.setContentsMargins(0, 0, 0, 0)
+        elev_container.setSpacing(8)
         self.elevation_edit = QLineEdit()
         self.elevation_edit.setValidator(validator)
         self.elevation_edit.setText("0")
@@ -87,30 +94,28 @@ class ISACalculatorDialog(QDialog):
         calc_group = QGroupBox("Calculation")
         calc_layout = QVBoxLayout(calc_group)
 
-        # Calculate button
+        # Calculate button — calculating also accepts and closes the dialog,
+        # applying the result to the caller immediately (no separate OK step)
         self.calculate_btn = QPushButton("🧮 Calculate ISA Variation")
         self.calculate_btn.setMinimumHeight(35)
         self.calculate_btn.clicked.connect(self.calculate_isa)
         calc_layout.addWidget(self.calculate_btn)
 
-        # Results display
-        self.result_label = QLabel("Click 'Calculate ISA Variation' to see results")
-        self.result_label.setStyleSheet("color: #666; font-style: italic; padding: 10px;")
-        self.result_label.setWordWrap(True)
-        calc_layout.addWidget(self.result_label)
+        # Hint label
+        self.hint_label = QLabel("Enter the values above, then click 'Calculate ISA Variation'.")
+        self.hint_label.setStyleSheet("color: #999; font-style: italic; padding: 10px;")
+        self.hint_label.setWordWrap(True)
+        calc_layout.addWidget(self.hint_label)
 
         layout.addWidget(calc_group)
 
-        # Dialog buttons
-        button_box = QDialogButtonBox(QDialogButtonBox_Ok | QDialogButtonBox_Cancel)
-        button_box.accepted.connect(self.accept_calculation)
-        button_box.rejected.connect(self.reject)
-
-        # Initially disable OK button
-        self.ok_button = button_box.button(QDialogButtonBox_Ok)
-        self.ok_button.setEnabled(False)
-
-        layout.addWidget(button_box)
+        # Cancel button (Calculate is the accept action, so no separate OK button)
+        cancel_row = QHBoxLayout()
+        cancel_row.addStretch()
+        self.cancel_btn = QPushButton("Cancel")
+        self.cancel_btn.clicked.connect(self.reject)
+        cancel_row.addWidget(self.cancel_btn)
+        layout.addLayout(cancel_row)
 
     def calculate_isa(self):
         """Calculate ISA variation"""
@@ -158,29 +163,13 @@ class ISACalculatorDialog(QDialog):
                 'isa_variation_calculated': isa_variation
             }
 
-            # Update result display
-            result_text = "✅ Calculation Complete\n\n"
-            result_text += f"ISA Temperature: {isa_temp:.5f}°C (at {elevation_ft:.0f} ft)\n"
-            result_text += f"ISA Variation: {isa_variation:.5f}°C\n"
-            result_text += "(Temperature Reference - ISA Temperature)"
-
-            self.result_label.setText(result_text)
-            self.result_label.setStyleSheet(
-                "color: #2e7d32; padding: 10px; background-color: #e8f5e8; border-radius: 5px;")
-
-            # Enable OK button
-            self.ok_button.setEnabled(True)
+            # Calculation succeeded — accept and close immediately, no extra
+            # confirmation step. The caller reads the result via
+            # get_isa_variation()/get_calculation_metadata() after exec().
+            self.accept()
 
         except Exception as e:
             QMessageBox.critical(self, "Calculation Error", f"Error calculating ISA Variation: {str(e)}")
-
-    def accept_calculation(self):
-        """Accept the calculation if valid"""
-        if self.isa_variation is not None:
-            self.accept()
-        else:
-            QMessageBox.warning(self, "No Calculation",
-                                "Please calculate ISA Variation before accepting")
 
     def get_isa_variation(self):
         """Get the calculated ISA variation"""

--- a/Q_Pansopy/metadata.txt
+++ b/Q_Pansopy/metadata.txt
@@ -32,6 +32,7 @@ changelog=
  - Store Area 1/2/3 distances (meters, 4 decimals) in the OMNI SID output attribute table
  - Combine VOR/DME and NDB/DME tolerance tools under one CONV toolbar dropdown icon and add LOC/DME Tolerance (2.4° default)
  - Fix Wind Spiral ISA calculator and Settings dialog crashing on QGIS 4 / Qt6 (QDialogButtonBox scoped enum, dlg.exec_() removed in PyQt6)
+ - Fix ISA Calculator dialog: invisible unit combo text on Windows, field alignment, default ISA Variation now 15, Calculate now closes the dialog immediately
  Version 0.4.0:
  - Fixes to initial realease to code logic including QGIS Plugin Store Compliance
  - PBN 15 NM and 30 NM targets included


### PR DESCRIPTION
# PR — ISA Calculator UI follow-up fixes (Issue #172)

## Summary

- Fixed the Aerodrome Elevation unit combo box (ft/m) rendering with invisible text on Windows
  in the ISA Calculator dialog.
- Fixed field alignment in the ISA Calculator's Input Parameters group.
- Changed the Wind Spiral tool's default ISA Variation from `0` to `15`.
- Calculating the ISA Variation now closes the dialog immediately and applies the result — no
  more separate, barely-visible green "Calculation Complete" message + OK click.

## Root cause / motivation

`Q_Pansopy/isa_calculator_dialog.py` is a standalone `QDialog`, unlike every dockwidget in this
plugin. Dockwidgets get a consistent dark theme (and correctly styled `QComboBox`) from
`styles/dockwidget_base.qss` via `load_base_qss()`
(`Q_Pansopy/dockwidgets/base_dockwidget.py`), but the ISA Calculator dialog never applied that
stylesheet. Its `QLineEdit`/`QPushButton`/`QGroupBox` happened to render fine under QGIS 4's
ambient dark theme, but the native Qt6/Windows `QComboBox` rendered with the accent color as
background and invisible text — confirmed from the reporter's screenshot.

The field misalignment was a missing `setContentsMargins(0, 0, 0, 0)` on the `QHBoxLayout`
wrapping the elevation edit + unit combo — every equivalent multi-widget field container
elsewhere in this codebase (e.g. `isa_layout`/`altitudeLayout` in
`qpansopy_wind_spiral_dockwidget.py`) sets this explicitly; this one didn't, so the default
Qt margin pushed that row a few pixels right of the Temperature Reference field below it.

The default ISA Variation and the extra OK-confirmation step were straightforward UX requests
from the issue reporter.

## Implementation notes

`_load_base_qss()` in `base_dockwidget.py` was renamed to `load_base_qss()` (dropping the
leading underscore now that it's used outside its original module) and is now also called from
`ISACalculatorDialog.__init__`.

`isa_calculator_dialog.py`'s `QFormLayout` now sets `setLabelAlignment`,
`setHorizontalSpacing`, and `setVerticalSpacing` matching the pattern already used in the Wind
Spiral dockwidget's dynamically-built form.

The dialog's action flow was simplified: `calculate_isa()` validates and computes as before, but
on success now calls `self.accept()` directly instead of enabling a separate `OK` button. The
`QDialogButtonBox(Ok | Cancel)` was replaced with a single `Cancel` button, since "Calculate" is
now the accept action. The now-unused `ok_button`, `result_label`, and `accept_calculation()`
were removed.

## Files Modified

| File | Change |
|---|---|
| `Q_Pansopy/dockwidgets/base_dockwidget.py` | Rename `_load_base_qss` → `load_base_qss` (now shared) |
| `Q_Pansopy/isa_calculator_dialog.py` | Apply `load_base_qss()`, fix field container margins/spacing and form alignment, calculate-and-close flow replacing the separate OK button/green message |
| `Q_Pansopy/dockwidgets/utilities/qpansopy_wind_spiral_dockwidget.py` | Default ISA Variation `"0.00000"` → `"15.00000"` |
| `Q_Pansopy/metadata.txt` | One changelog bullet under Version 0.4.1 |
| `docs/plan-172-followup.md` | Implementation plan |

## Test plan

- [x] `pytest tests/ -q` — no regressions.
- [x] Flake8: 0 new findings (`isa_calculator_dialog.py`/`base_dockwidget.py` clean; the
  1-line change in `qpansopy_wind_spiral_dockwidget.py` introduces no new findings).
- [ ] QGIS 4 / Windows: Wind Spiral tool → ISA Variation defaults to `15.00000` → calculator
  button opens the dialog → unit combo clearly shows "ft"/"m" → fields are aligned → Calculate
  with valid inputs closes the dialog immediately and fills `isaVarLineEdit` → Cancel closes
  without applying anything → invalid input shows a warning and keeps the dialog open.

## Related

Re-closes #172.
