### PR TITLE
Wind Spiral live rubberband preview (Issue #173)

### DIFF
--- a/Q_Pansopy/dockwidgets/utilities/qpansopy_wind_spiral_dockwidget.py
+++ b/Q_Pansopy/dockwidgets/utilities/qpansopy_wind_spiral_dockwidget.py
@@ -24,11 +24,14 @@ Procedure Analysis and Obstacle Protection Surfaces - Wind Spiral Module
 import os
 from qgis.PyQt import QtWidgets, uic
 from qgis.PyQt.QtCore import pyqtSignal, QRegularExpression, QMimeData
-from qgis.PyQt.QtGui import QRegularExpressionValidator
+from qgis.PyQt.QtGui import QRegularExpressionValidator, QColor
 from qgis.PyQt.QtWidgets import QMessageBox
 from ...qt_compat import Qt_AlignRight, Qt_AlignVCenter, Qt_AlignLeft, Qt_AlignTop, MLPM_PointLayer, MLPM_LineLayer, preseed_active_layer, Qgis_GeomType_Line
-from qgis.core import QgsProject, QgsVectorLayer, QgsWkbTypes, QgsCoordinateReferenceSystem, QgsMapLayerProxyModel
-from qgis.gui import QgsMapLayerComboBox  # Importar QgsMapLayerComboBox
+from qgis.core import (
+    QgsProject, QgsVectorLayer, QgsWkbTypes, QgsCoordinateReferenceSystem,
+    QgsMapLayerProxyModel, QgsCoordinateTransform, QgsPoint,
+)
+from qgis.gui import QgsMapLayerComboBox, QgsRubberBand  # Importar QgsMapLayerComboBox
 from qgis.core import Qgis
 import json
 import datetime
@@ -76,7 +79,18 @@ class QPANSOPYWindSpiralDockWidgetBase(QtWidgets.QDockWidget, FORM_CLASS):
         if hasattr(self, 'referenceLayerComboBox'):
             self.referenceLayerComboBox.setFilters(MLPM_LineLayer)
             preseed_active_layer(iface, self.referenceLayerComboBox, Qgis_GeomType_Line)
-        
+
+        # Live preview rubber band — updated as layers/parameters change
+        self._preview_band = QgsRubberBand(iface.mapCanvas(), Qgis_GeomType_Line)
+        self._preview_band.setColor(QColor("green"))
+        self._preview_band.setWidth(2)
+        self._connected_layers = []
+
+        if hasattr(self, 'pointLayerComboBox'):
+            self.pointLayerComboBox.layerChanged.connect(self._on_layer_changed)
+        if hasattr(self, 'referenceLayerComboBox'):
+            self.referenceLayerComboBox.layerChanged.connect(self._on_layer_changed)
+
         # Set default output folder
         if hasattr(self, 'outputFolderLineEdit'):
             self.outputFolderLineEdit.setText(self.get_desktop_path())
@@ -91,6 +105,10 @@ class QPANSOPYWindSpiralDockWidgetBase(QtWidgets.QDockWidget, FORM_CLASS):
 
         # Setup parameter input fields dynamically
         self.setup_dynamic_parameters()
+
+        # Populate the preview now that both layer combos and parameter
+        # widgets exist
+        self._on_layer_changed()
 
         # Log initial message
         self.log("Wind Spiral generator loaded. Set parameters and click Calculate.")
@@ -133,6 +151,7 @@ class QPANSOPYWindSpiralDockWidgetBase(QtWidgets.QDockWidget, FORM_CLASS):
         self.isaVarLineEdit.setText("15.00000")
         self.isaVarLineEdit.textChanged.connect(
             lambda text: self.handle_isa_manual_change(text))
+        self.isaVarLineEdit.textChanged.connect(self._update_preview)
         self.isaVarLineEdit.setMinimumHeight(28)
         self.isaVarLineEdit.setMaximumHeight(28)
         self.isaVarLineEdit.setStyleSheet(line_edit_style)
@@ -163,6 +182,7 @@ class QPANSOPYWindSpiralDockWidgetBase(QtWidgets.QDockWidget, FORM_CLASS):
         self.IASLineEdit.setText("205")
         self.IASLineEdit.textChanged.connect(
             lambda text: self.store_exact_value('IAS', text))
+        self.IASLineEdit.textChanged.connect(self._update_preview)
         self.IASLineEdit.setMinimumHeight(28)
         self.IASLineEdit.setMaximumHeight(28)
         self.IASLineEdit.setStyleSheet(line_edit_style)
@@ -174,6 +194,7 @@ class QPANSOPYWindSpiralDockWidgetBase(QtWidgets.QDockWidget, FORM_CLASS):
         self.altitudeLineEdit.setText("800")
         self.altitudeLineEdit.textChanged.connect(
             lambda text: self.store_exact_value('altitude', text))
+        self.altitudeLineEdit.textChanged.connect(self._update_preview)
         self.altitudeLineEdit.setMinimumHeight(28)
         self.altitudeLineEdit.setMaximumHeight(28)
         self.altitudeLineEdit.setStyleSheet(line_edit_style)
@@ -182,6 +203,7 @@ class QPANSOPYWindSpiralDockWidgetBase(QtWidgets.QDockWidget, FORM_CLASS):
         self.altitudeUnitCombo.addItems(['ft', 'm'])
         self.altitudeUnitCombo.currentTextChanged.connect(
             lambda text: self.update_unit('altitude', text))
+        self.altitudeUnitCombo.currentTextChanged.connect(self._update_preview)
         self.altitudeUnitCombo.setMinimumHeight(28)
         self.altitudeUnitCombo.setMaximumHeight(28)
         self.altitudeUnitCombo.setMinimumWidth(50)
@@ -203,6 +225,7 @@ class QPANSOPYWindSpiralDockWidgetBase(QtWidgets.QDockWidget, FORM_CLASS):
         self.bankAngleLineEdit.setText("15")
         self.bankAngleLineEdit.textChanged.connect(
             lambda text: self.store_exact_value('bankAngle', text))
+        self.bankAngleLineEdit.textChanged.connect(self._update_preview)
         self.bankAngleLineEdit.setMinimumHeight(28)
         self.bankAngleLineEdit.setMaximumHeight(28)
         self.bankAngleLineEdit.setStyleSheet(line_edit_style)
@@ -214,6 +237,7 @@ class QPANSOPYWindSpiralDockWidgetBase(QtWidgets.QDockWidget, FORM_CLASS):
         self.windSpeedLineEdit.setText("30")
         self.windSpeedLineEdit.textChanged.connect(
             lambda text: self.store_exact_value('w', text))
+        self.windSpeedLineEdit.textChanged.connect(self._update_preview)
         self.windSpeedLineEdit.setMinimumHeight(28)
         self.windSpeedLineEdit.setMaximumHeight(28)
         self.windSpeedLineEdit.setStyleSheet(line_edit_style)
@@ -225,6 +249,7 @@ class QPANSOPYWindSpiralDockWidgetBase(QtWidgets.QDockWidget, FORM_CLASS):
         self.turnDirectionCombo.setMinimumHeight(28)
         self.turnDirectionCombo.setMaximumHeight(28)
         self.turnDirectionCombo.setStyleSheet(combo_box_style)
+        self.turnDirectionCombo.currentTextChanged.connect(self._update_preview)
         self.formLayout.addRow("Turn Direction:", self.turnDirectionCombo)
 
         # Show Points checkbox
@@ -421,8 +446,85 @@ class QPANSOPYWindSpiralDockWidgetBase(QtWidgets.QDockWidget, FORM_CLASS):
             "QPANSOPY", "Wind Spiral parameters copied to clipboard as JSON", level=Qgis.Success)
 
     def closeEvent(self, event):
+        self._clear_preview()
         self.closingPlugin.emit()
         event.accept()
+
+    def _on_layer_changed(self, *args):
+        """Re-hook selectionChanged on whichever layers are currently chosen."""
+        for lyr in self._connected_layers:
+            try:
+                lyr.selectionChanged.disconnect(self._update_preview)
+            except Exception:
+                pass
+        self._connected_layers = []
+
+        seen = set()
+        for combo in [self.pointLayerComboBox, self.referenceLayerComboBox]:
+            lyr = combo.currentLayer()
+            if lyr and id(lyr) not in seen:
+                lyr.selectionChanged.connect(self._update_preview)
+                self._connected_layers.append(lyr)
+                seen.add(id(lyr))
+
+        self._update_preview()
+
+    def _clear_preview(self):
+        if getattr(self, '_preview_band', None):
+            self._preview_band.reset(Qgis_GeomType_Line)
+
+    def _update_preview(self, *args):
+        """Recompute the live rubber-band preview of the wind spiral curve."""
+        self._clear_preview()
+
+        point_layer = self.pointLayerComboBox.currentLayer()
+        reference_layer = self.referenceLayerComboBox.currentLayer()
+        if not point_layer or not reference_layer:
+            return
+
+        try:
+            from ...utils import get_selected_feature
+            point_feature = get_selected_feature(point_layer, lambda msg: None)
+            reference_feature = get_selected_feature(reference_layer, lambda msg: None)
+            if not point_feature or not reference_feature:
+                return
+
+            map_crs = self.iface.mapCanvas().mapSettings().destinationCrs()
+            project = QgsProject.instance()
+
+            def to_map(feat, lyr):
+                g = feat.geometry()
+                g.transform(QgsCoordinateTransform(lyr.crs(), map_crs, project))
+                return g
+
+            point_geom = to_map(point_feature, point_layer).asPoint()
+            ref_polyline = to_map(reference_feature, reference_layer).asPolyline()
+            if len(ref_polyline) < 2:
+                return
+
+            start_point = QgsPoint(ref_polyline[-1])
+            end_point = QgsPoint(ref_polyline[0])
+            azimuth = start_point.azimuth(end_point) + 180
+
+            isa_var = float(self.isaVarLineEdit.text() or 0)
+            IAS = float(self.IASLineEdit.text() or 0)
+            altitude = float(self.altitudeLineEdit.text() or 0)
+            if self.units.get('altitude', 'ft') == 'm':
+                altitude = altitude * 3.28084
+            bank_angle = float(self.bankAngleLineEdit.text() or 0)
+            wind_speed = float(self.windSpeedLineEdit.text() or 0)
+            turn_direction = self.turnDirectionCombo.currentText()
+
+            if IAS <= 0 or altitude <= 0 or bank_angle <= 0:
+                return
+
+            from ...modules.wind_spiral import build_wind_spiral_geometry
+            geom = build_wind_spiral_geometry(
+                point_geom, azimuth, IAS, altitude, isa_var, bank_angle, wind_speed, turn_direction)
+            if geom and not geom.isEmpty():
+                self._preview_band.setToGeometry(geom, None)
+        except Exception:
+            pass
 
     def validate_inputs(self):
         """Validate user inputs"""
@@ -536,6 +638,7 @@ class QPANSOPYWindSpiralDockWidgetBase(QtWidgets.QDockWidget, FORM_CLASS):
             result = calculate_wind_spiral(self.iface, point_layer, reference_layer, params)
 
             if result:
+                self._clear_preview()
                 if export_kml:
                     self.log(f"Wind Spiral KML exported to: {result.get('spiral_path', 'N/A')}")
                 self.log("Calculation completed successfully!")

--- a/Q_Pansopy/metadata.txt
+++ b/Q_Pansopy/metadata.txt
@@ -33,6 +33,8 @@ changelog=
  - Combine VOR/DME and NDB/DME tolerance tools under one CONV toolbar dropdown icon and add LOC/DME Tolerance (2.4° default)
  - Fix Wind Spiral ISA calculator and Settings dialog crashing on QGIS 4 / Qt6 (QDialogButtonBox scoped enum, dlg.exec_() removed in PyQt6)
  - Fix ISA Calculator dialog: invisible unit combo text on Windows, field alignment, default ISA Variation now 15, Calculate now closes the dialog immediately
+ - Add live green rubber-band preview of the wind spiral curve, updated as parameters/layers change
+ - Fix Wind Spiral ISA Variation field being silently ignored by the actual calculation
  Version 0.4.0:
  - Fixes to initial realease to code logic including QGIS Plugin Store Compliance
  - PBN 15 NM and 30 NM targets included

--- a/Q_Pansopy/modules/wind_spiral.py
+++ b/Q_Pansopy/modules/wind_spiral.py
@@ -43,6 +43,85 @@ def tas_calculation(ias, altitude, var, bank_angle, wind_speed=30):
     return k, tas, rate_of_turn, radius_of_turn, w
 
 
+def build_wind_spiral_points(p_geom, azimuth, IAS, altitude, isa_var, bank_angle,
+                              wind_speed, turn_direction='R'):
+    """
+    Pure geometry builder for the wind spiral curve (no QGIS layers/project
+    side effects) — shared by the real calculation and the live preview.
+
+    :param p_geom: Reference point geometry (QgsPoint/QgsPointXY, map CRS)
+    :param azimuth: True azimuth of the reference track, in degrees
+    :param IAS: Indicated Air Speed in knots
+    :param altitude: Altitude in feet
+    :param isa_var: ISA temperature deviation in degrees C
+    :param bank_angle: Bank angle in degrees
+    :param wind_speed: Wind speed in knots
+    :param turn_direction: 'R' or 'L'
+    :return: (u_points, center_point) where u_points is a list of QgsPoint
+        starting at p_geom followed by one drift point per 30 deg step
+        (used both for the circular-string curve and the optional
+        'show points' marker layer), and center_point is a QgsPoint for the
+        turn's center.
+    """
+    if turn_direction == "L":
+        side = 90
+        d = (30, 60, 90, 120, 150, 180, 210, 240, 270, 300, 330)  # NM
+    else:  # Default to right turn
+        side = -90
+        d = (-30, -60, -90, -120, -150, -180, -210, -240, -270, -300, -330)  # NM
+
+    values = tas_calculation(IAS, altitude, isa_var, bank_angle, wind_speed=wind_speed)
+    r_turn = values[3]
+
+    # Calculate drift angle - Original Formula
+    drift_angle = math.asin(values[4] / values[1])
+
+    # Calculate wind spiral radii - Original Formula
+    wind_spiral_radius = {}
+    for i in range(30, 390, 30):
+        windspiral = (i / values[2]) * (values[4] / 3600)
+        wind_spiral_radius["radius_" + str(i)] = windspiral
+
+    u = [QgsPoint(p_geom)]
+
+    # Calculate center point
+    angle = 90 - azimuth + side  # left/right
+    angle = math.radians(angle)
+    dist_x, dist_y = (r_turn * 1852 * math.cos(angle), r_turn * 1852 * math.sin(angle))
+    xc, yc = (p_geom.x() + dist_x, p_geom.y() + dist_y)
+    center_point = QgsPoint(xc, yc)
+
+    # Calculate points for wind spiral
+    for i in d:
+        e = list(wind_spiral_radius.values())[int(abs(i) / 30) - 1]
+
+        angle = 90 - azimuth + i - side
+        angle = math.radians(angle)
+
+        # Calculate point on circle
+        dist_x, dist_y = (r_turn * 1852 * math.cos(angle), r_turn * 1852 * math.sin(angle))
+        cx1, cy2 = (center_point.x() + dist_x, center_point.y() + dist_y)
+
+        # Calculate drift point
+        dist_xd, dist_yd = (e * 1852 * math.cos(angle - drift_angle * (side / 90)),
+                          e * 1852 * math.sin(angle - drift_angle * (side / 90)))
+        dx1, dy2 = (cx1 + dist_xd, cy2 + dist_yd)
+
+        u.append(QgsPoint(dx1, dy2))
+
+    return u, center_point
+
+
+def build_wind_spiral_geometry(p_geom, azimuth, IAS, altitude, isa_var, bank_angle,
+                                wind_speed, turn_direction='R'):
+    """QgsGeometry (circular string) for live preview / rubber band use."""
+    u, _ = build_wind_spiral_points(p_geom, azimuth, IAS, altitude, isa_var,
+                                     bank_angle, wind_speed, turn_direction)
+    cString = QgsCircularString()
+    cString.setPoints(u)
+    return QgsGeometry(cString)
+
+
 def calculate_wind_spiral(iface, point_layer, reference_layer, params):
     """
     Create Wind Spiral
@@ -66,28 +145,19 @@ def calculate_wind_spiral(iface, point_layer, reference_layer, params):
     export_kml = params.get('export_kml', True)
     output_dir = params.get('output_dir', os.path.expanduser('~'))
 
-    # Get aerodrome elevation and temperature reference from params
-    adElev = float(params.get('adElev', 0))
-    adElev_unit = params.get('adElev_unit', 'ft')
-    if adElev_unit == 'm':
-        adElev = adElev * 3.28084
-    tempRef = float(params.get('tempRef', 15))
-
-    # Calculate ISA temperature and deviation
-    valueISA = ISA_temperature(adElev, tempRef)
-    isa_var = valueISA[3]  # Use the calculated ISA deviation
+    # ISA deviation comes directly from the dockwidget's ISA Variation field
+    # (params['isaVar']) — adElev/tempRef are legacy inputs no longer collected
+    # by the Wind Spiral UI; they're only used by the standalone ISA Calculator
+    # dialog, whose result is what populates isaVar.
+    isa_var = float(params.get('isaVar', 0))
 
     # Create a parameters dictionary for JSON storage
     parameters_dict = {
-        'adElev': str(adElev),
-        'adElev_unit': adElev_unit,
-        'tempRef': str(tempRef),
         'IAS': str(IAS),
         'altitude': str(altitude),
         'altitude_unit': altitude_unit,
         'bankAngle': str(bankAngle),
         'w': str(w),
-        'isa_calculated': str(round(valueISA[2], 2)),
         'isa_var': str(round(isa_var, 2)),
         'turn_direction': turn_direction,
         'calculation_date': datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
@@ -95,33 +165,12 @@ def calculate_wind_spiral(iface, point_layer, reference_layer, params):
     }
     parameters_json = json.dumps(parameters_dict)
 
-    # Log ISA calculation results
+    # Log ISA deviation used in the calculation
     iface.messageBar().pushMessage(
         "Info",
-        f"ISA Temperature: {round(valueISA[2], 2)}°C, ISA Deviation: {round(isa_var, 2)}°C",
+        f"ISA Deviation used: {round(isa_var, 2)}°C",
         level=Qgis.Info
     )
-
-    # Set turn direction
-    if turn_direction == "L":
-        side = 90
-        d = (30, 60, 90, 120, 150, 180, 210, 240, 270, 300, 330)  # NM
-    else:  # Default to right turn
-        side = -90
-        d = (-30, -60, -90, -120, -150, -180, -210, -240, -270, -300, -330)  # NM
-
-    # Calculate TAS and turn parameters using original formula
-    values = tas_calculation(IAS, altitude, isa_var, bankAngle, wind_speed=w)
-    r_turn = values[3]
-
-    # Calculate drift angle - Original Formula
-    drift_angle = math.asin(values[4]/values[1])
-
-    # Calculate wind spiral radii - Original Formula
-    wind_spiral_radius = {}
-    for i in range(30, 390, 30):
-        windspiral = (i/values[2])*(values[4]/3600)
-        wind_spiral_radius["radius_" + str(i)] = windspiral
 
     # Get map CRS
     map_srid = iface.mapCanvas().mapSettings().destinationCrs().authid()
@@ -155,9 +204,10 @@ def calculate_wind_spiral(iface, point_layer, reference_layer, params):
     # Get point geometry
     p_geom = point_feature.geometry().asPoint()
 
-    # Initialize points list for circular string
-    u = []
-    u.append(QgsPoint(p_geom))
+    # Build the spiral curve points (shared pure geometry builder, also used
+    # by the dockwidget's live rubber-band preview)
+    u, center_point = build_wind_spiral_points(
+        p_geom, azimuth, IAS, altitude, isa_var, bankAngle, w, turn_direction)
 
     # Create point layer if requested
     if show_points:
@@ -167,59 +217,16 @@ def calculate_wind_spiral(iface, point_layer, reference_layer, params):
         v_layer.updateFields()
         pr = v_layer.dataProvider()
 
-        # Calculate center point
-        angle = 90 - azimuth + side  # left/right
-        bearing = math.radians(azimuth)
-        angle = math.radians(angle)
-        dist_x, dist_y = (r_turn * 1852 * math.cos(angle), r_turn * 1852 * math.sin(angle))
-        xc, yc = (p_geom.x() + dist_x, p_geom.y() + dist_y)
-        line_start = QgsPointXY(xc, yc)
-
         # Add center point
         seg = QgsFeature()
-        seg.setGeometry(QgsGeometry.fromPointXY(line_start))
+        seg.setGeometry(QgsGeometry.fromPoint(center_point))
         seg.setAttributes(['Wind Spiral Center'])
         pr.addFeatures([seg])
 
-        # Get angle from Center to P
-        connect_line = QgsGeometry.fromPolyline([QgsPoint(line_start), QgsPoint(p_geom)])
-        start_point_C = QgsPoint(connect_line.asPolyline()[0])
-    else:
-        # Calculate center point without creating layer
-        angle = 90 - azimuth + side
-        bearing = math.radians(azimuth)
-        angle = math.radians(angle)
-        dist_x, dist_y = (r_turn * 1852 * math.cos(angle), r_turn * 1852 * math.sin(angle))
-        xc, yc = (p_geom.x() + dist_x, p_geom.y() + dist_y)
-        line_start = QgsPointXY(xc, yc)
-        start_point_C = QgsPoint(line_start)
-
-    # Calculate points for wind spiral
-    for i in d:
-        e = list(wind_spiral_radius.values())[int(abs(i) / 30) - 1]
-
-        bearing = azimuth
-        angle = 90 - bearing + i - side
-        bearing = math.radians(bearing)
-        angle = math.radians(angle)
-
-        # Calculate point on circle
-        dist_x, dist_y = (r_turn * 1852 * math.cos(angle), r_turn * 1852 * math.sin(angle))
-        cx1, cy2 = (start_point_C.x() + dist_x, start_point_C.y() + dist_y)
-
-        # Calculate drift point
-        dist_xd, dist_yd = (e * 1852 * math.cos(angle - drift_angle * (side / 90)),
-                          e * 1852 * math.sin(angle - drift_angle * (side / 90)))
-        dx1, dy2 = (cx1 + dist_xd, cy2 + dist_yd)
-        line_startd = QgsPointXY(dx1, dy2)
-
-        # Add point to circular string
-        u.append(QgsPoint(line_startd))
-
-        # Add drift point to point layer if requested
-        if show_points:
+        # Add each drift point
+        for drift_point in u[1:]:
             seg = QgsFeature()
-            seg.setGeometry(QgsGeometry.fromPointXY(line_startd))
+            seg.setGeometry(QgsGeometry.fromPoint(drift_point))
             seg.setAttributes(['drift_angle'])
             pr.addFeatures([seg])
 


### PR DESCRIPTION
# PR — Wind Spiral live rubberband preview (Issue #173)

## Summary

- Added a live green rubber-band preview of the wind spiral curve on the map canvas, updated in
  real time as the user edits IAS, Altitude, Bank Angle, Wind Speed, ISA Variation, Turn
  Direction, or changes the point/reference layer or feature selection — matching the preview
  pattern already used by the DME Tolerance and Omnidirectional SID tools.
- Fixed a pre-existing bug where the Wind Spiral tool's ISA Variation field had no effect on the
  actual calculation: `calculate_wind_spiral()` was silently recomputing ISA deviation from
  `adElev`/`tempRef` params the dockwidget never sends (always defaulting to `0`/`15`), instead
  of using the `isaVar` value it was actually given.

## Root cause / motivation

The Wind Spiral calculation module (`Q_Pansopy/modules/wind_spiral.py`) had no pure,
side-effect-free geometry builder to reuse for a preview — the spiral-curve math was entangled
with memory-layer creation and KML export inside `calculate_wind_spiral()`, the same gap already
solved for the DME Tolerance tool via `build_tolerance_geometry()`.

While extracting that math it became clear `calculate_wind_spiral()` derives its ISA deviation
from `ISA_temperature(adElev, tempRef)`, but the dockwidget's `calculate()` never includes
`adElev`/`tempRef` in `params` (those fields don't exist in this tool's UI anymore — they were
superseded by the standalone ISA Calculator dialog, which populates `isaVar` directly). So
`adElev`/`tempRef` always fell back to their defaults (`0`/`15`), making the derived ISA
deviation always `0` — the ISA Variation field the user actually edits was completely inert.
Since the new live preview needs to reflect that field to be useful, this was fixed in the same
change.

## Implementation notes

`build_wind_spiral_points(p_geom, azimuth, IAS, altitude, isa_var, bank_angle, wind_speed,
turn_direction)` is the new pure function (in `wind_spiral.py`) holding the turn-direction
selection, `tas_calculation()`, drift angle, per-30° radii, and the point-generation loop; it
returns `(u_points, center_point)`. `build_wind_spiral_geometry(...)` wraps it into a
`QgsGeometry` (circular string) for preview use. `calculate_wind_spiral()` now calls
`build_wind_spiral_points()` once and reuses its result for both the real curve and the optional
"show points" marker layer, instead of duplicating the math inline.

The dockwidget follows the exact structure of `qpansopy_dme_tolerance_dockwidget.py`: a
`QgsRubberBand` created in `__init__`, `_on_layer_changed()` re-hooking `selectionChanged` on
whichever layers are current, and `_update_preview()` doing the CRS transform + azimuth + build +
`setToGeometry()` dance, wrapped in a broad `try/except` since invalid/partial input while typing
is expected and should just skip the update rather than error.

## Files Modified

| File | Change |
|---|---|
| `Q_Pansopy/modules/wind_spiral.py` | Extract `build_wind_spiral_points()`/`build_wind_spiral_geometry()`; `calculate_wind_spiral()` reuses them; fix `isa_var` to read `params['isaVar']` directly |
| `Q_Pansopy/dockwidgets/utilities/qpansopy_wind_spiral_dockwidget.py` | Add live preview `QgsRubberBand`, `_on_layer_changed()`/`_clear_preview()`/`_update_preview()`, wire all parameter widgets + layer combos to it |
| `Q_Pansopy/metadata.txt` | Two changelog bullets under Version 0.4.1 |
| `docs/plan-173-wind-spiral-rubberband-preview.md` | Implementation plan |

## Test plan

- [x] `pytest tests/ -q` — no regressions.
- [x] Flake8: no new findings.
- [ ] QGIS: Wind Spiral tool with a point layer + reference line layer selected (one feature
  each) shows a live green spiral preview immediately; editing any parameter or switching layers
  updates it in real time; Calculate produces the identical curve as an output layer and clears
  the preview; closing the dockwidget removes the preview band.
- [ ] QGIS: compare a calculation with ISA Variation `15` vs `0` and confirm the resulting
  geometry/radius actually differs (previously it never did).

## Related

Closes #173.
