### PR TITLE
Add reference line to SID Initial tool (Issue #174)

### DIFF
--- a/Q_Pansopy/dockwidgets/departures/qpansopy_sid_initial_dockwidget.py
+++ b/Q_Pansopy/dockwidgets/departures/qpansopy_sid_initial_dockwidget.py
@@ -315,6 +315,8 @@ class QPANSOPYSIDInitialDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
                 self.log(f"TAS: {result['tas_kt']:.2f}kt")
                 self.log(f"Rate of Turn: {result['rate_of_turn']:.2f}°/s")
                 self.log(f"Radius of Turn: {result['radius_of_turn_nm']:.2f}NM")
+                if 'reference_line_layer' in result:
+                    self.log(f"Reference line layer: {result['reference_line_layer']}")
                 self.log("Results copied to clipboard.")
             else:
                 self.log("Calculation completed but no results returned.")

--- a/Q_Pansopy/metadata.txt
+++ b/Q_Pansopy/metadata.txt
@@ -33,6 +33,7 @@ changelog=
  - Combine VOR/DME and NDB/DME tolerance tools under one CONV toolbar dropdown icon and add LOC/DME Tolerance (2.4° default)
  - Fix Wind Spiral ISA calculator and Settings dialog crashing on QGIS 4 / Qt6 (QDialogButtonBox scoped enum, dlg.exec_() removed in PyQt6)
  - Fix ISA Calculator dialog: invisible unit combo text on Windows, field alignment, default ISA Variation now 15, Calculate now closes the dialog immediately
+ - Add reference line output layer to the SID Initial Climb tool, matching the OMNI SID reference line
  Version 0.4.0:
  - Fixes to initial realease to code logic including QGIS Plugin Store Compliance
  - PBN 15 NM and 30 NM targets included

--- a/Q_Pansopy/modules/departures/sid_initial_climb.py
+++ b/Q_Pansopy/modules/departures/sid_initial_climb.py
@@ -54,6 +54,9 @@ SPLAY_ANGLE = 15
 # Maximum rate of turn per ICAO (degrees/second)
 MAX_RATE_OF_TURN = 3
 
+# Reference line buffer beyond the widest downstream area boundary (0.5 NM, in meters)
+REFERENCE_LINE_BUFFER_M = 0.5 * 1852
+
 
 # =============================================================================
 # HELPER FUNCTIONS
@@ -324,6 +327,16 @@ def run_sid_initial_climb(iface, runway_layer, params, log_callback=None):
     c_point_left = point_with_z(c_point_center.project(width_at_c, azimuth - 90), 0.0)
     c_point_right = point_with_z(c_point_center.project(width_at_c, azimuth + 90), 0.0)
 
+    # Reference line at the DER, 0.5 NM wider on each side than the c Area's
+    # outer boundary (the widest downstream section) — used later for
+    # downstream calculations.
+    reference_half_width = width_at_c + REFERENCE_LINE_BUFFER_M
+    reference_line_left = point_with_z(end_point.project(reference_half_width, azimuth - 90), 0.0)
+    reference_line_right = point_with_z(end_point.project(reference_half_width, azimuth + 90), 0.0)
+
+    log(f"Reference line half-width: {reference_half_width:.2f}m "
+        f"({reference_half_width / 1852:.2f}NM)")
+
     # -------------------------------------------------------------------------
     # Create protection areas layer
     # -------------------------------------------------------------------------
@@ -359,6 +372,34 @@ def run_sid_initial_climb(iface, runway_layer, params, log_callback=None):
     areas_layer.triggerRepaint()
 
     QgsProject.instance().addMapLayers([areas_layer])
+
+    # -------------------------------------------------------------------------
+    # Create reference line layer
+    # -------------------------------------------------------------------------
+    reference_line_layer_name = "SID Initial Reference Line"
+    reference_line_layer = QgsVectorLayer(
+        f"LineString?crs={map_crs}",
+        reference_line_layer_name,
+        "memory"
+    )
+    reference_line_layer.dataProvider().addAttributes([QgsField('id', QVariant.String)])
+    reference_line_layer.updateFields()
+
+    reference_line_geometry = QgsGeometry.fromPolyline([
+        reference_line_left, end_point, reference_line_right
+    ])
+    reference_line_feature = QgsFeature()
+    reference_line_feature.setGeometry(reference_line_geometry)
+    reference_line_feature.setAttributes(['reference_line'])
+    reference_line_layer.dataProvider().addFeatures([reference_line_feature])
+
+    reference_line_layer.updateExtents()
+    reference_line_layer.renderer().symbol().setColor(QColor("purple"))
+    reference_line_layer.renderer().symbol().setWidth(0.5)
+    reference_line_layer.triggerRepaint()
+
+    QgsProject.instance().addMapLayers([reference_line_layer])
+    log(f"Reference line layer added: {reference_line_layer_name}")
 
     # -------------------------------------------------------------------------
     # Create construction lines layer
@@ -425,6 +466,8 @@ def run_sid_initial_climb(iface, runway_layer, params, log_callback=None):
     log("Turn Initiation Area created")
     log("c Area created")
     log("Construction lines created")
+    log(f"Reference line layer: {reference_line_layer_name} "
+        f"(half-width {reference_half_width:.2f}m)")
     log(f"Distance to TNA/H: {tna_distance_nm:.4f}NM")
     log(f"TAS: {tas_values['tas_kt']:.2f}kt")
     log(f"Rate of Turn: {tas_values['rate_of_turn']:.2f}°/s")
@@ -435,6 +478,8 @@ def run_sid_initial_climb(iface, runway_layer, params, log_callback=None):
     return {
         'areas_layer': 'SID Protection Areas',
         'lines_layer': 'SID Construction Lines',
+        'reference_line_layer': reference_line_layer_name,
+        'reference_line_half_width': reference_half_width,
         'tna_distance_nm': tna_distance_nm,
         'tas_kt': tas_values['tas_kt'],
         'rate_of_turn': tas_values['rate_of_turn'],


### PR DESCRIPTION
# PR — Add reference line to SID Initial tool (Issue #174)

## Summary

- Added a dedicated purple reference-line output layer to the SID Initial Climb tool, positioned
  at the DER and perpendicular to the runway azimuth, matching the reference line already added
  to the Omnidirectional SID tool in #171.

## Root cause / motivation

Issue #174 explicitly requests the same treatment given to OMNI SID in #171. The SID Initial
Climb tool had no reference line output at all — only the "SID Protection Areas" (TIA + c Area
polygons) and "SID Construction Lines" (TNA/H Reached + SS Line) layers.

## Implementation notes

The reference line follows the exact structure introduced for OMNI SID: a fixed half-width
(`width_at_c + 0.5 NM`) projected from the DER (`end_point`) perpendicular to the runway azimuth,
where `width_at_c` is this tool's widest downstream boundary (the c Area's outer edge) — the
direct analog of OMNI SID's `width_area_2`. The layer itself is a 3-point polyline (left → DER →
right), styled purple/width 0.5, added to the project alongside the existing output layers, with
its name and half-width returned in the result dict and logged by the dockwidget.

## Files Modified

| File | Change |
|---|---|
| `Q_Pansopy/modules/departures/sid_initial_climb.py` | Add `REFERENCE_LINE_BUFFER_M`, compute reference line endpoints from `end_point`/`width_at_c`, build the `"SID Initial Reference Line"` layer, add it to the result dict |
| `Q_Pansopy/dockwidgets/departures/qpansopy_sid_initial_dockwidget.py` | Log the reference line layer name when present in the result |
| `Q_Pansopy/metadata.txt` | One changelog bullet under Version 0.4.1 |
| `docs/plan-174-sid-initial-reference-line.md` | Implementation plan |

## Test plan

- [x] `pytest tests/ -q` — no regressions.
- [x] Flake8: no new findings.
- [ ] QGIS: run SID Initial Climb with a runway layer selected → `"SID Initial Reference Line"`
  layer appears at the DER, perpendicular to the runway, spanning the c Area's outer boundary
  plus margin → existing "SID Protection Areas"/"SID Construction Lines" outputs unchanged.

## Related

Closes #174.
