### PR TITLE
Fix "Use selection only" ignored for Surface layer (Issue #175)

### DIFF
--- a/Q_Pansopy/metadata.txt
+++ b/Q_Pansopy/metadata.txt
@@ -33,6 +33,7 @@ changelog=
  - Combine VOR/DME and NDB/DME tolerance tools under one CONV toolbar dropdown icon and add LOC/DME Tolerance (2.4° default)
  - Fix Wind Spiral ISA calculator and Settings dialog crashing on QGIS 4 / Qt6 (QDialogButtonBox scoped enum, dlg.exec_() removed in PyQt6)
  - Fix ISA Calculator dialog: invisible unit combo text on Windows, field alignment, default ISA Variation now 15, Calculate now closes the dialog immediately
+ - Fix Object Selection tool ignoring "Use selection only" for the Surface layer
  Version 0.4.0:
  - Fixes to initial realease to code logic including QGIS Plugin Store Compliance
  - PBN 15 NM and 30 NM targets included

--- a/Q_Pansopy/modules/utilities/selection_of_objects.py
+++ b/Q_Pansopy/modules/utilities/selection_of_objects.py
@@ -36,6 +36,7 @@ def extract_objects(iface, point_layer, surface_layer,
     :param export_kml: Whether to export the result to a KML file
     :param output_dir: Directory for the KML file (required when export_kml=True)
     :param use_selection_only: Only process currently-selected features of point_layer
+        and surface_layer
     :return: dict with 'count' and optionally 'kml_path', or None on failure
     """
     map_crs = QgsProject.instance().crs()
@@ -73,7 +74,13 @@ def extract_objects(iface, point_layer, surface_layer,
         work_layer = point_layer
 
     # ----- Spatial index & intersection test -----
-    surface_index = QgsSpatialIndex(surface_layer.getFeatures())
+    surface_source_features = (
+        surface_layer.selectedFeatures() if use_selection_only
+        else surface_layer.getFeatures()
+    )
+    surface_index = QgsSpatialIndex()
+    for f in surface_source_features:
+        surface_index.addFeature(f)
     intersecting_features = []
 
     source_features = (


### PR DESCRIPTION
# PR — Fix "Use selection only" ignored for Surface layer (Issue #175)

## Summary

- Fixed the Object Selection tool's "Use selection only" checkbox having no effect on the
  Surface layer — obstacle points were still tested against every surface feature even when a
  single surface polygon was selected and the box was checked.

## Root cause / motivation

`Q_Pansopy/modules/utilities/selection_of_objects.py::extract_objects()` already branched
correctly on `use_selection_only` for the point layer (both the optional-reprojection step and
the main iteration), but the spatial index built for the surface layer
(`QgsSpatialIndex(surface_layer.getFeatures())`) always indexed every surface feature regardless
of the flag. The dockwidget's checkbox wiring was already correct — the bug was entirely inside
the calculation module.

## Implementation notes

The surface-layer feature source is now chosen with the same ternary pattern already used for
the point layer elsewhere in this function:
```python
surface_source_features = (
    surface_layer.selectedFeatures() if use_selection_only
    else surface_layer.getFeatures()
)
surface_index = QgsSpatialIndex()
for f in surface_source_features:
    surface_index.addFeature(f)
```
No change was needed where the spatial-index candidate ids are later used to fetch surface
features by id (`setFilterFids(candidate_ids)`) — since those ids now only ever come from the
(correctly scoped) index, that lookup is automatically limited to the selected surface(s) too.

## Files Modified

| File | Change |
|---|---|
| `Q_Pansopy/modules/utilities/selection_of_objects.py` | Scope the surface spatial index to `selectedFeatures()` when `use_selection_only` is set |
| `Q_Pansopy/metadata.txt` | One changelog bullet under Version 0.4.1 |
| `docs/plan-175-object-selection-use-selection-only.md` | Implementation plan |

## Test plan

- [x] `pytest tests/ -q` — no regressions.
- [x] Flake8: 0 findings.
- [ ] QGIS: select one polygon in the Surface layer, check "Use selection only", click Extract →
  only obstacle points intersecting that one selected surface are extracted → unchecking the box
  (or with no selection) still processes every surface feature as before.

## Related

Closes #175.
