### PR TITLE
Allow more decimals in OMNI SID DER Elevation / PDG fields (Issue #176)

### DIFF
--- a/Q_Pansopy/metadata.txt
+++ b/Q_Pansopy/metadata.txt
@@ -33,6 +33,7 @@ changelog=
  - Combine VOR/DME and NDB/DME tolerance tools under one CONV toolbar dropdown icon and add LOC/DME Tolerance (2.4° default)
  - Fix Wind Spiral ISA calculator and Settings dialog crashing on QGIS 4 / Qt6 (QDialogButtonBox scoped enum, dlg.exec_() removed in PyQt6)
  - Fix ISA Calculator dialog: invisible unit combo text on Windows, field alignment, default ISA Variation now 15, Calculate now closes the dialog immediately
+ - Allow more than 2 decimal places in the OMNI SID DER Elevation and PDG fields
  Version 0.4.0:
  - Fixes to initial realease to code logic including QGIS Plugin Store Compliance
  - PBN 15 NM and 30 NM targets included

--- a/Q_Pansopy/ui/departures/qpansopy_omnidirectional_dockwidget.ui
+++ b/Q_Pansopy/ui/departures/qpansopy_omnidirectional_dockwidget.ui
@@ -112,7 +112,7 @@
             <double>1.000000000000000</double>
            </property>
            <property name="decimals">
-            <number>2</number>
+            <number>4</number>
            </property>
           </widget>
          </item>
@@ -160,7 +160,7 @@
           <double>3.300000000000000</double>
          </property>
          <property name="decimals">
-          <number>2</number>
+          <number>4</number>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
# PR — Allow more decimals in OMNI SID DER Elevation / PDG fields (Issue #176)

## Summary

- The Omnidirectional SID tool's "DER Elevation" and "PDG (%)" fields now accept up to 4 decimal
  places instead of being capped at 2.

## Root cause / motivation

Both fields are `QDoubleSpinBox` widgets defined in
`Q_Pansopy/ui/departures/qpansopy_omnidirectional_dockwidget.ui` with
`decimals` hardcoded to `2`. This was purely a UI input-precision cap — the underlying
`.value()` calls already return full double precision, so no other code needed to change.

## Files Modified

| File | Change |
|---|---|
| `Q_Pansopy/ui/departures/qpansopy_omnidirectional_dockwidget.ui` | `derElevationSpinBox`/`pdgSpinBox` `decimals` 2 → 4 |
| `Q_Pansopy/metadata.txt` | One changelog bullet under Version 0.4.1 |
| `docs/plan-176-omni-der-pdg-decimals.md` | Implementation plan |

## Test plan

- [x] `pytest tests/ -q` — no regressions.
- [x] `.ui` XML parses cleanly.
- [ ] QGIS: OMNI SID tool — DER Elevation and PDG fields accept/display up to 4 decimal places.

## Related

Closes #176.
