### PR TITLE
OMNI SID parameters (Issue #177)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 *.pyc
 *.pyo
 *.pyd
+*.zip
 
 # pytest / coverage
 .pytest_cache/
@@ -18,6 +19,7 @@ tests/results/
 #agents skills
 .agents/
 .claude/
+.augment/
 CLAUDE.md
 skills-lock.json
 .idea/
@@ -26,12 +28,6 @@ skills-lock.json
 doc/
 docs/
 DEVELOPMENT_PLAN.md
-
-#python cache
-__pycache__/
-*.pyc
-*.pyo
-*.zip
 
 .venv/
 .idea/

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ __pycache__/
 *.pyc
 *.pyo
 *.zip
+
+.venv/
+.idea/

--- a/Q_Pansopy/metadata.txt
+++ b/Q_Pansopy/metadata.txt
@@ -37,6 +37,7 @@ changelog=
  - Fix Wind Spiral ISA Variation field being silently ignored by the actual calculation
  - Update PBN Target layer style: thinner outline (0.25mm) and add ARP-distance labels
  - Fix Basic ILS missed approach surface lateral half-width formula (was incorrectly using a flat 15% splay instead of the 14.3% transition-slope-derived offset), restoring parity with the reference script
+ - Store all input parameters (DER elevation, PDG, TNA, MSA, CWY distance, options) as a JSON 'parameters' field on every OMNI SID output feature (areas, reference line, construction points)
  Version 0.4.0:
  - Fixes to initial realease to code logic including QGIS Plugin Store Compliance
  - PBN 15 NM and 30 NM targets included

--- a/Q_Pansopy/modules/departures/omnidirectional_sid.py
+++ b/Q_Pansopy/modules/departures/omnidirectional_sid.py
@@ -39,6 +39,8 @@ from qgis.core import (
 from qgis.PyQt.QtCore import QVariant
 from qgis.PyQt.QtGui import QColor
 from math import tan, radians
+import datetime
+import json
 
 
 # =============================================================================
@@ -202,7 +204,33 @@ def create_projected_point(point_name, origin_point, distance, azimuth, elevatio
     points_dict[point_name] = projected_point
 
 
-def create_polygon_surface(surface_name, vertices, layer, surfaces_dict, distance_m=None):
+def _build_omni_parameters_json(params, der_elevation_m, pdg_percent, tna_ft, msa_ft,
+                                 cwy_distance_m, allow_turns_before_der,
+                                 include_construction_points, reverse_direction):
+    """
+    Build the JSON string stored in the 'parameters' field of every OMNI SID
+    output feature, so the inputs used to generate a layer are recoverable
+    from the data itself (issue #177) instead of only from the layer name.
+    """
+    parameters_dict = {
+        'der_elevation_m': der_elevation_m,
+        'der_elevation_unit': params.get('der_elevation_unit', 'm'),
+        'pdg': pdg_percent,
+        'TNA_ft': tna_ft,
+        'msa_ft': msa_ft,
+        'cwy_distance_m': cwy_distance_m,
+        'cwy_distance_unit': params.get('cwy_distance_unit', 'm'),
+        'allow_turns_before_der': allow_turns_before_der,
+        'include_construction_points': include_construction_points,
+        'reverse_direction': reverse_direction,
+        'calculation_date': datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+        'calculation_type': 'Omnidirectional SID',
+    }
+    return json.dumps(parameters_dict)
+
+
+def create_polygon_surface(surface_name, vertices, layer, surfaces_dict, parameters_json,
+                            distance_m=None):
     """
     Create a 3D polygon surface and add it to a layer.
 
@@ -215,6 +243,8 @@ def create_polygon_surface(surface_name, vertices, layer, surfaces_dict, distanc
         vertices (list): List of QgsPoint vertices forming the polygon.
         layer (QgsVectorLayer): Layer to add the feature to.
         surfaces_dict (dict): Dictionary to store the geometry for later use.
+        parameters_json (str): JSON string of the input parameters used for this
+            calculation run, stored in the 'parameters' field.
         distance_m (float, optional): Area distance in meters, stored rounded
             to 4 decimal places in the 'distance_m' field. None (NULL) when
             not applicable to this surface.
@@ -223,7 +253,11 @@ def create_polygon_surface(surface_name, vertices, layer, surfaces_dict, distanc
     feature = QgsFeature()
     polygon = QgsPolygon(QgsLineString(vertices), rings=[])
     feature.setGeometry(polygon)
-    feature.setAttributes([surface_name, round(distance_m, 4) if distance_m is not None else None])
+    feature.setAttributes([
+        surface_name,
+        round(distance_m, 4) if distance_m is not None else None,
+        parameters_json,
+    ])
     provider.addFeatures([feature])
     surfaces_dict[surface_name] = feature.geometry()
 
@@ -329,6 +363,11 @@ def run_omnidirectional_sid(iface, runway_layer, params, log_callback=None):
     allow_turns_before_der = params.get('allow_turns_before_der', 'NO')
     include_construction_points = params.get('include_construction_points', 'NO')
     reverse_direction = params.get('reverse_direction', 'NO')
+
+    parameters_json = _build_omni_parameters_json(
+        params, der_elevation_m, pdg_percent, tna_ft, msa_ft, cwy_distance_m,
+        allow_turns_before_der, include_construction_points, reverse_direction
+    )
 
     log(f"Parameters: DER Elev={der_elevation_m}m, PDG={pdg_percent}%, "
         f"TNA={tna_ft}ft, MSA={msa_ft}ft")
@@ -488,14 +527,17 @@ def run_omnidirectional_sid(iface, runway_layer, params, log_callback=None):
         f"OmniSID_Construction_Points_PDG_{pdg_percent}",
         "memory"
     )
-    construction_layer.dataProvider().addAttributes([QgsField('id', QVariant.String)])
+    construction_layer.dataProvider().addAttributes([
+        QgsField('id', QVariant.String),
+        QgsField('parameters', QVariant.String),
+    ])
     construction_layer.updateFields()
 
     for point_name, point_geometry in construction_points.items():
         provider = construction_layer.dataProvider()
         feature = QgsFeature()
         feature.setGeometry(point_geometry)
-        feature.setAttributes([point_name])
+        feature.setAttributes([point_name, parameters_json])
         provider.addFeatures([feature])
 
     if include_construction_points == 'YES':
@@ -511,7 +553,10 @@ def run_omnidirectional_sid(iface, runway_layer, params, log_callback=None):
         reference_line_layer_name,
         "memory"
     )
-    reference_line_layer.dataProvider().addAttributes([QgsField('id', QVariant.String)])
+    reference_line_layer.dataProvider().addAttributes([
+        QgsField('id', QVariant.String),
+        QgsField('parameters', QVariant.String),
+    ])
     reference_line_layer.updateFields()
 
     reference_line_geometry = QgsGeometry.fromPolyline([
@@ -519,7 +564,7 @@ def run_omnidirectional_sid(iface, runway_layer, params, log_callback=None):
     ])
     reference_line_feature = QgsFeature()
     reference_line_feature.setGeometry(reference_line_geometry)
-    reference_line_feature.setAttributes(['reference_line'])
+    reference_line_feature.setAttributes(['reference_line', parameters_json])
     reference_line_layer.dataProvider().addFeatures([reference_line_feature])
 
     reference_line_layer.updateExtents()
@@ -541,7 +586,8 @@ def run_omnidirectional_sid(iface, runway_layer, params, log_callback=None):
     )
     surfaces_layer.dataProvider().addAttributes([
         QgsField('omni_area', QVariant.String),
-        QgsField('distance_m', QVariant.Double, 'double', 10, 4)
+        QgsField('distance_m', QVariant.Double, 'double', 10, 4),
+        QgsField('parameters', QVariant.String),
     ])
     surfaces_layer.updateFields()
 
@@ -560,7 +606,8 @@ def run_omnidirectional_sid(iface, runway_layer, params, log_callback=None):
         ],
         surfaces_layer,
         surfaces_geometries,
-        distance_area_1
+        parameters_json,
+        distance_m=distance_area_1
     )
 
     # Create Area 2 polygon
@@ -576,7 +623,8 @@ def run_omnidirectional_sid(iface, runway_layer, params, log_callback=None):
         ],
         surfaces_layer,
         surfaces_geometries,
-        distance_area_2
+        parameters_json,
+        distance_m=distance_area_2
     )
 
     # Create Before DER area if enabled
@@ -592,7 +640,8 @@ def run_omnidirectional_sid(iface, runway_layer, params, log_callback=None):
                 construction_points['point_0_center']
             ],
             surfaces_layer,
-            surfaces_geometries
+            surfaces_geometries,
+            parameters_json
         )
 
     # -------------------------------------------------------------------------
@@ -615,7 +664,7 @@ def run_omnidirectional_sid(iface, runway_layer, params, log_callback=None):
     provider = surfaces_layer.dataProvider()
     area_3_feature = QgsFeature()
     area_3_feature.setGeometry(area_3_geometry)
-    area_3_feature.setAttributes(['Area 3', round(distance_area_3, 4)])
+    area_3_feature.setAttributes(['Area 3', round(distance_area_3, 4), parameters_json])
     provider.addFeatures([area_3_feature])
 
     surfaces_layer.updateExtents()

--- a/tests/unit/test_omnidirectional_sid_parameters.py
+++ b/tests/unit/test_omnidirectional_sid_parameters.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+"""
+Regression tests for issue #177: OMNI SID output features must carry the
+input parameters used to generate them (previously only recoverable from
+the PDG baked into the layer name).
+"""
+import importlib
+import json
+
+
+def test_build_omni_parameters_json_round_trips_all_keys():
+    mod = importlib.import_module('Q_Pansopy.modules.departures.omnidirectional_sid')
+
+    params = {'der_elevation_unit': 'm', 'cwy_distance_unit': 'm'}
+    parameters_json = mod._build_omni_parameters_json(
+        params, der_elevation_m=39.92, pdg_percent=3.3, tna_ft=600, msa_ft=1800,
+        cwy_distance_m=60, allow_turns_before_der='NO',
+        include_construction_points='NO', reverse_direction='YES',
+    )
+    parsed = json.loads(parameters_json)
+
+    assert parsed['der_elevation_m'] == 39.92
+    assert parsed['der_elevation_unit'] == 'm'
+    assert parsed['pdg'] == 3.3
+    assert parsed['TNA_ft'] == 600
+    assert parsed['msa_ft'] == 1800
+    assert parsed['cwy_distance_m'] == 60
+    assert parsed['cwy_distance_unit'] == 'm'
+    assert parsed['allow_turns_before_der'] == 'NO'
+    assert parsed['include_construction_points'] == 'NO'
+    assert parsed['reverse_direction'] == 'YES'
+    assert parsed['calculation_type'] == 'Omnidirectional SID'
+    assert 'calculation_date' in parsed
+
+
+def test_create_polygon_surface_stores_parameters_json(monkeypatch):
+    mod = importlib.import_module('Q_Pansopy.modules.departures.omnidirectional_sid')
+
+    class _FakeFeature:
+        def __init__(self):
+            self.attributes = None
+            self._geom = object()
+
+        def setGeometry(self, geom):
+            pass
+
+        def setAttributes(self, attrs):
+            self.attributes = attrs
+
+        def geometry(self):
+            return self._geom
+
+    created = []
+
+    def _fake_feature_factory():
+        feature = _FakeFeature()
+        created.append(feature)
+        return feature
+
+    monkeypatch.setattr(mod, 'QgsFeature', _fake_feature_factory)
+
+    class _FakeProvider:
+        def addFeatures(self, feats):
+            pass
+
+    class _FakeLayer:
+        def dataProvider(self):
+            return _FakeProvider()
+
+    surfaces_dict = {}
+    parameters_json = '{"pdg": 3.3}'
+
+    mod.create_polygon_surface(
+        'Area 1', [1, 2, 3], _FakeLayer(), surfaces_dict, parameters_json,
+        distance_m=1234.5678
+    )
+
+    assert len(created) == 1
+    assert created[0].attributes == ['Area 1', 1234.5678, parameters_json]
+    assert surfaces_dict['Area 1'] is created[0].geometry()
+
+
+def test_create_polygon_surface_distance_none_when_not_applicable(monkeypatch):
+    mod = importlib.import_module('Q_Pansopy.modules.departures.omnidirectional_sid')
+
+    class _FakeFeature:
+        def __init__(self):
+            self.attributes = None
+
+        def setGeometry(self, geom):
+            pass
+
+        def setAttributes(self, attrs):
+            self.attributes = attrs
+
+        def geometry(self):
+            return object()
+
+    created = []
+    monkeypatch.setattr(mod, 'QgsFeature', lambda: created.append(_FakeFeature()) or created[-1])
+
+    class _FakeLayer:
+        def dataProvider(self):
+            class _P:
+                def addFeatures(self, feats):
+                    pass
+            return _P()
+
+    parameters_json = '{"pdg": 3.3}'
+    mod.create_polygon_surface(
+        'Before DER', [1, 2, 3], _FakeLayer(), {}, parameters_json
+    )
+
+    assert created[0].attributes == ['Before DER', None, parameters_json]


### PR DESCRIPTION
# PR — OMNI SID parameters (Issue #177)

## Summary

- Every OMNI SID output feature (Area 1/2/3, "Before DER", construction points, reference line)
  now carries a `parameters` field: a JSON string of every input used to generate it (DER
  elevation + unit, PDG, TNA, MSA, CWY distance + unit, allow-turns-before-DER,
  include-construction-points, direction, calculation date/type).
- Previously the only trace of any parameter was the PDG value baked into the output layer names
  — renaming or exporting a layer lost that context entirely.

## Root cause

`Q_Pansopy/modules/departures/omnidirectional_sid.py` never stored input parameters on features,
unlike `basic_ils.py`/`oas_ils.py`/`vss_straight.py`/`vss_loc.py`/`wind_spiral.py`, which already
established a `parameters` (JSON) field convention for exactly this purpose. OMNI SID simply
never adopted it (and didn't even import `json`).

## Implementation notes

- New `_build_omni_parameters_json(...)` builds the dict once per run from the already-parsed
  calculation inputs and returns `json.dumps(...)`.
- `create_polygon_surface()` (used for Area 1, Area 2, and the optional "Before DER" area) gained
  a `parameters_json` argument appended to `setAttributes()`; the direct Area 3 `setAttributes()`
  call was updated the same way.
- `surfaces_layer`, `construction_layer`, and `reference_line_layer` each gained a
  `QgsField('parameters', QVariant.String)` and now set it on every feature — all three layers
  come from the same tool run, so the same JSON string is written to all of them.

## Files Modified

| File | Change |
|---|---|
| `Q_Pansopy/modules/departures/omnidirectional_sid.py` | Added `parameters` JSON field to all three output layers |
| `tests/unit/test_omnidirectional_sid_parameters.py` | New tests for the JSON builder and `create_polygon_surface` |
| `Q_Pansopy/metadata.txt` | One changelog bullet under Version 0.4.1 |
| `docs/plan-177.md` | Implementation plan |

## Test plan

- [x] `pytest tests/ -q` — no regressions, new tests pass.
- [x] `flake8`/`bandit` on the touched files — 0 findings.
- [ ] Run OMNI SID in QGIS with the parameters from the issue screenshot (DER Elev 39.92m, PDG
  3.3%, TNA 600ft, MSA 1800ft, CWY 60m) and confirm the `parameters` column is populated and
  correct on Area 1/2/3, the reference line, and construction points.

## Related

Closes #177.
