### PR TITLE
Feat/193 parameters inspector action

### DIFF
--- a/Q_Pansopy/dockwidgets/departures/qpansopy_sid_initial_dockwidget.py
+++ b/Q_Pansopy/dockwidgets/departures/qpansopy_sid_initial_dockwidget.py
@@ -27,7 +27,7 @@ import json
 import datetime
 
 from qgis.PyQt import QtWidgets, uic
-from qgis.PyQt.QtCore import pyqtSignal, Qt, QMimeData
+from qgis.PyQt.QtCore import pyqtSignal, Qt
 from qgis.core import QgsMapLayerProxyModel, Qgis
 from ...qt_compat import DOCK_FEATURES_DEFAULT, Qt_ALLOWED_DOCK_AREAS, MLPM_LineLayer, preseed_active_layer, Qgis_GeomType_Line
 
@@ -106,8 +106,8 @@ class QPANSOPYSIDInitialDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         """Configure buttons to copy parameters to clipboard."""
         buttons_layout = QtWidgets.QHBoxLayout()
 
-        self.copyParamsWordButton = QtWidgets.QPushButton("Copy for Word", self)
-        self.copyParamsWordButton.clicked.connect(self.copy_parameters_for_word)
+        self.copyParamsWordButton = QtWidgets.QPushButton("Show Table", self)
+        self.copyParamsWordButton.clicked.connect(self.show_parameters_table)
         self.copyParamsWordButton.setMinimumHeight(30)
 
         self.copyParamsJsonButton = QtWidgets.QPushButton("Copy as JSON", self)
@@ -136,8 +136,9 @@ class QPANSOPYSIDInitialDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         else:
             self.directionButton.setText("Start → End")
 
-    def copy_parameters_for_word(self):
-        """Copy SID Initial parameters as HTML table for Word."""
+    def show_parameters_table(self):
+        """Show SID Initial parameters as a rendered HTML table.
+        The popup itself offers a 'Copy to Word' button (issue #193)."""
         params = self.get_parameters()
 
         param_list = [
@@ -173,26 +174,16 @@ class QPANSOPYSIDInitialDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
 
         html += '</table>'
 
-        # Set both HTML and plain text to clipboard
-        mime_data = QMimeData()
-        mime_data.setHtml(html)
-
-        # Also set plain text as fallback
         plain_text = "SID INITIAL CLIMB CALCULATION PARAMETERS\n"
         plain_text += "=" * 50 + "\n\n"
         for name, value, unit in param_list:
             plain_text += f"{name}\t{value}\t{unit}\n"
-        mime_data.setText(plain_text)
 
-        clipboard = QtWidgets.QApplication.clipboard()
-        clipboard.setMimeData(mime_data)
-
-        self.log("Parameters copied as table for Word.")
-        self.iface.messageBar().pushMessage(
-            "QPANSOPY",
-            "SID Initial parameters copied as table - paste in Word",
-            level=Qgis.Success
-        )
+        from ...parameters_inspector_dialog import ParametersInspectorDialog
+        dialog = ParametersInspectorDialog(
+            "SID Initial Climb — Feature Parameters", html, plain_text, parent=self)
+        dialog.show()
+        self.log("SID Initial parameters shown in Parameters Inspector.")
 
     def copy_parameters_as_json(self):
         """Copy SID Initial parameters in JSON format."""

--- a/Q_Pansopy/dockwidgets/ils/qpansopy_ils_dockwidget.py
+++ b/Q_Pansopy/dockwidgets/ils/qpansopy_ils_dockwidget.py
@@ -116,9 +116,9 @@ class QPANSOPYILSDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
        # Crear un layout horizontal para los botones
        buttons_layout = QtWidgets.QHBoxLayout()
 
-       # Botón para copiar como texto formateado (Word)
-       self.copyParamsWordButton = QtWidgets.QPushButton("Copy for Word", self)
-       self.copyParamsWordButton.clicked.connect(self.copy_parameters_for_word)
+       # Botón para mostrar los parámetros como tabla (con opción de copiar a Word)
+       self.copyParamsWordButton = QtWidgets.QPushButton("Show Table", self)
+       self.copyParamsWordButton.clicked.connect(self.show_parameters_table)
        self.copyParamsWordButton.setMinimumHeight(30)
 
        # Botón para copiar como JSON
@@ -196,8 +196,8 @@ class QPANSOPYILSDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
        self.log("Parameters copied to clipboard. You can now paste them into Word or another application.")
        self.iface.messageBar().pushMessage("QPANSOPY", "Parameters copied to clipboard", level=Qgis.Success)
 
-   def copy_parameters_for_word(self):
-       """Copiar los parámetros en formato tabla para Word"""
+   def show_parameters_table(self):
+       """Mostrar los parámetros como una tabla HTML, con opción de copiar a Word"""
        layers = QgsProject.instance().mapLayers().values()
        vector_layers = [layer for layer in layers if isinstance(layer, QgsVectorLayer)]
        params_text = ""
@@ -269,13 +269,12 @@ class QPANSOPYILSDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
            params_text += "No Basic ILS parameters found in any layer. Please run a calculation first.\n"
            html_blocks.append("<p>No Basic ILS parameters found in any layer. Please run a calculation first.</p>")
 
-       mime = QMimeData()
-       mime.setHtml("<div>" + "<br>".join(html_blocks) + "</div>")
-       mime.setText(params_text)
-       clipboard = QtWidgets.QApplication.clipboard()
-       clipboard.setMimeData(mime)
-       self.log("Parameters copied to clipboard as a table for Word.")
-       self.iface.messageBar().pushMessage("QPANSOPY", "Parameters copied to clipboard in Word format", level=Qgis.Success)
+       from ...parameters_inspector_dialog import ParametersInspectorDialog
+       html_table = "<div>" + "<br>".join(html_blocks) + "</div>"
+       dialog = ParametersInspectorDialog(
+           "Basic ILS — Feature Parameters", html_table, params_text, parent=self)
+       dialog.show()
+       self.log("Basic ILS parameters shown in Parameters Inspector.")
 
    def copy_parameters_as_json(self):
        """Copiar los parámetros de las capas seleccionadas al portapapeles en formato JSON"""

--- a/Q_Pansopy/dockwidgets/ils/qpansopy_oas_ils_dockwidget.py
+++ b/Q_Pansopy/dockwidgets/ils/qpansopy_oas_ils_dockwidget.py
@@ -26,7 +26,7 @@ import json
 import datetime
 import traceback
 from qgis.PyQt import QtWidgets, uic
-from qgis.PyQt.QtCore import pyqtSignal, QRegularExpression, QMimeData
+from qgis.PyQt.QtCore import pyqtSignal, QRegularExpression
 from qgis.PyQt.QtGui import QRegularExpressionValidator
 from qgis.core import QgsProject, QgsVectorLayer
 from qgis.core import Qgis
@@ -147,9 +147,9 @@ class QPANSOPYOASILSDockWidgetBase(QtWidgets.QDockWidget, FORM_CLASS):
        # Crear un layout horizontal para los botones
        buttons_layout = QtWidgets.QHBoxLayout()
 
-       # Botón para copiar como texto formateado (Word)
-       self.copyParamsWordButton = QtWidgets.QPushButton("Copy for Word", self)
-       self.copyParamsWordButton.clicked.connect(self.copy_parameters_for_word)
+       # Botón para mostrar los parámetros como tabla (con opción de copiar a Word)
+       self.copyParamsWordButton = QtWidgets.QPushButton("Show Table", self)
+       self.copyParamsWordButton.clicked.connect(self.show_parameters_table)
        self.copyParamsWordButton.setMinimumHeight(30)
 
        # Botón para copiar como JSON
@@ -167,8 +167,8 @@ class QPANSOPYOASILSDockWidgetBase(QtWidgets.QDockWidget, FORM_CLASS):
        # Añadir el widget al layout existente
        self.verticalLayout.addWidget(buttons_widget)
 
-   def copy_parameters_for_word(self):
-       """Copiar los parámetros OAS ILS en formato tabla para Word"""
+   def show_parameters_table(self):
+       """Mostrar los parámetros OAS ILS como una tabla HTML, con opción de copiar a Word"""
        from ...utils import format_parameters_table
 
        layers = QgsProject.instance().mapLayers().values()
@@ -240,14 +240,12 @@ class QPANSOPYOASILSDockWidgetBase(QtWidgets.QDockWidget, FORM_CLASS):
 
        html_content = "<div>" + "<br>".join(html_chunks) + "</div>"
        plain_content = "\n\n".join(text_chunks)
-       mime = QMimeData()
-       mime.setHtml(html_content)
-       mime.setText(plain_content)
-       clipboard = QtWidgets.QApplication.clipboard()
-       clipboard.setMimeData(mime)
 
-       self.log("OAS ILS parameters copied to clipboard in Word format (HTML table).")
-       self.iface.messageBar().pushMessage("QPANSOPY", "OAS ILS parameters copied to clipboard in Word format", level=Qgis.Success)
+       from ...parameters_inspector_dialog import ParametersInspectorDialog
+       dialog = ParametersInspectorDialog(
+           "OAS ILS — Feature Parameters", html_content, plain_content, parent=self)
+       dialog.show()
+       self.log("OAS ILS parameters shown in Parameters Inspector.")
 
    def copy_parameters_as_json(self):
        """Copiar los parámetros de las capas seleccionadas al portapapeles en formato JSON"""

--- a/Q_Pansopy/dockwidgets/utilities/qpansopy_holding_dockwidget.py
+++ b/Q_Pansopy/dockwidgets/utilities/qpansopy_holding_dockwidget.py
@@ -1,6 +1,6 @@
 import os
 from qgis.PyQt import QtWidgets, uic
-from qgis.PyQt.QtCore import pyqtSignal, QMimeData
+from qgis.PyQt.QtCore import pyqtSignal
 from qgis.core import QgsMapLayerProxyModel, Qgis
 from ...qt_compat import MLPM_LineLayer, preseed_active_layer, Qgis_GeomType_Line
 
@@ -29,7 +29,8 @@ class QPANSOPYHoldingDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         # Signals
         self.calculateButton.clicked.connect(self.calculate)
         self.browseButton.clicked.connect(self._browse)
-        self.copyWordButton.clicked.connect(self.copy_to_word)
+        self.copyWordButton.setText("Show Table")
+        self.copyWordButton.clicked.connect(self.show_parameters_table)
 
     def closeEvent(self, event):
         self.closingPlugin.emit()
@@ -100,10 +101,12 @@ class QPANSOPYHoldingDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
             self.log(f"Error during calculation: {e}")
             self.log(traceback.format_exc())
 
-    def copy_to_word(self):
+    def show_parameters_table(self):
+        """Show the last calculation's parameters as a rendered HTML table.
+        The popup itself offers a 'Copy to Word' button (issue #193)."""
         summary = self.last_summary
         if not summary:
-            self.log('Error: No calculation available to copy')
+            self.log('Error: No calculation available to show')
             return
 
         rows = [
@@ -132,8 +135,8 @@ class QPANSOPYHoldingDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         html_rows.append("</table>")
         html_table = "".join(html_rows)
 
-        mime = QMimeData()
-        mime.setHtml(html_table)
-        mime.setText(table_text)
-        QtWidgets.QApplication.clipboard().setMimeData(mime)
-        self.log('Summary copied to clipboard as Word-friendly table')
+        from ...parameters_inspector_dialog import ParametersInspectorDialog
+        dialog = ParametersInspectorDialog(
+            "Holding Pattern — Feature Parameters", html_table, table_text, parent=self)
+        dialog.show()
+        self.log('Holding pattern parameters shown in Parameters Inspector.')

--- a/Q_Pansopy/dockwidgets/utilities/qpansopy_vss_dockwidget.py
+++ b/Q_Pansopy/dockwidgets/utilities/qpansopy_vss_dockwidget.py
@@ -23,7 +23,7 @@ Procedure Analysis and Obstacle Protection Surfaces - VSS Module
 
 import os
 from qgis.PyQt import QtWidgets, uic
-from qgis.PyQt.QtCore import pyqtSignal, QRegularExpression, QMimeData
+from qgis.PyQt.QtCore import pyqtSignal, QRegularExpression
 from qgis.PyQt.QtGui import QRegularExpressionValidator
 from qgis.core import Qgis
 from ...qt_compat import DOCK_FEATURES_DEFAULT, FORM_FIELD_ROLE, Qt_ALLOWED_DOCK_AREAS, MLPM_PointLayer, MLPM_LineLayer, preseed_active_layer, Qgis_GeomType_Line
@@ -81,7 +81,8 @@ class QPANSOPYVSSDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
 
         # Conectar botones de copia si existen en el UI
         if hasattr(self, 'copyWordButton'):
-            self.copyWordButton.clicked.connect(self.copy_parameters_for_word)
+            self.copyWordButton.setText("Show Table")
+            self.copyWordButton.clicked.connect(self.show_parameters_table)
         if hasattr(self, 'copyJsonButton'):
             self.copyJsonButton.clicked.connect(self.copy_parameters_as_json)
 
@@ -128,8 +129,8 @@ class QPANSOPYVSSDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         """DEPRECATED: Buttons are now defined in the UI XML."""
         pass
 
-    def copy_parameters_for_word(self):
-        """Copiar los parámetros VSS como tabla para Word"""
+    def show_parameters_table(self):
+        """Mostrar los parámetros VSS como una tabla HTML, con opción de copiar a Word"""
         params = {
             'runway_details': {
                 'rwy_width': {'value': self.exact_values.get('rwy_width', self.rwyWidthLineEdit.text()), 'unit': 'm'},
@@ -171,14 +172,11 @@ class QPANSOPYVSSDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
             as_html=False
         )
 
-        mime = QMimeData()
-        mime.setHtml(html_table)
-        mime.setText(text_table)
-        clipboard = QtWidgets.QApplication.clipboard()
-        clipboard.setMimeData(mime)
-        self.log("VSS parameters copied to clipboard as a Word table.")
-        self.iface.messageBar().pushMessage(
-            "QPANSOPY", "VSS parameters copied to clipboard in Word format", level=Qgis.Success)
+        from ...parameters_inspector_dialog import ParametersInspectorDialog
+        dialog = ParametersInspectorDialog(
+            "VSS — Feature Parameters", html_table, text_table, parent=self)
+        dialog.show()
+        self.log("VSS parameters shown in Parameters Inspector.")
 
     def copy_parameters_as_json(self):
         """Copiar los parámetros actuales al portapapeles en formato JSON"""

--- a/Q_Pansopy/dockwidgets/utilities/qpansopy_wind_spiral_dockwidget.py
+++ b/Q_Pansopy/dockwidgets/utilities/qpansopy_wind_spiral_dockwidget.py
@@ -23,7 +23,7 @@ Procedure Analysis and Obstacle Protection Surfaces - Wind Spiral Module
 
 import os
 from qgis.PyQt import QtWidgets, uic
-from qgis.PyQt.QtCore import pyqtSignal, QRegularExpression, QMimeData
+from qgis.PyQt.QtCore import pyqtSignal, QRegularExpression
 from qgis.PyQt.QtGui import QRegularExpressionValidator, QColor
 from qgis.PyQt.QtWidgets import QMessageBox
 from ...qt_compat import Qt_AlignRight, Qt_AlignVCenter, Qt_AlignLeft, Qt_AlignTop, MLPM_PointLayer, MLPM_LineLayer, preseed_active_layer, Qgis_GeomType_Line
@@ -101,7 +101,8 @@ class QPANSOPYWindSpiralDockWidgetBase(QtWidgets.QDockWidget, FORM_CLASS):
         if hasattr(self, 'browseButton'):
             self.browseButton.clicked.connect(self.browse_output_folder)
         if hasattr(self, 'copyParamsButton'):
-            self.copyParamsButton.clicked.connect(self.copy_parameters_for_word)
+            self.copyParamsButton.setText("Show Table")
+            self.copyParamsButton.clicked.connect(self.show_parameters_table)
 
         # Setup parameter input fields dynamically
         self.setup_dynamic_parameters()
@@ -313,9 +314,10 @@ class QPANSOPYWindSpiralDockWidgetBase(QtWidgets.QDockWidget, FORM_CLASS):
         else:
             print(f"Wind Spiral: {message}")
 
-    def copy_parameters_for_word(self):
-        """Copy parameters in a Word-friendly table format.
+    def show_parameters_table(self):
+        """Show the last calculation's parameters as a rendered HTML table.
         Prefers reading from output layer 'parameters' JSON; falls back to current UI values.
+        The popup itself offers a 'Copy to Word' button (issue #193).
         """
         # Try reading from output layers first
         try:
@@ -348,16 +350,13 @@ class QPANSOPYWindSpiralDockWidgetBase(QtWidgets.QDockWidget, FORM_CLASS):
                         'turn_direction': data.get('turn_direction', 'R')
                     }
                     from ...modules.wind_spiral import copy_parameters_table
+                    from ...parameters_inspector_dialog import ParametersInspectorDialog
                     html_table = copy_parameters_table(mapped, as_html=True)
                     text_table = copy_parameters_table(mapped, as_html=False)
-                    mime = QMimeData()
-                    mime.setHtml(html_table)
-                    mime.setText(text_table)
-                    clipboard = QtWidgets.QApplication.clipboard()
-                    clipboard.setMimeData(mime)
-                    self.log("Wind Spiral parameters (from layer) copied to clipboard as a Word table.")
-                    self.iface.messageBar().pushMessage(
-                        "QPANSOPY", "Wind Spiral parameters copied (from layer)", level=Qgis.Success)
+                    dialog = ParametersInspectorDialog(
+                        "Wind Spiral — Feature Parameters", html_table, text_table, parent=self)
+                    dialog.show()
+                    self.log("Wind Spiral parameters (from layer) shown in Parameters Inspector.")
                     return
         except Exception as e:
             # Non-fatal; fall back to UI values
@@ -396,13 +395,11 @@ class QPANSOPYWindSpiralDockWidgetBase(QtWidgets.QDockWidget, FORM_CLASS):
                 text_table += f"{name:<25}\t{value}\t\t{unit}\n"
             html_table = text_table.replace("\n", "<br>")
 
-        mime = QMimeData()
-        mime.setHtml(html_table)
-        mime.setText(text_table)
-        clipboard = QtWidgets.QApplication.clipboard()
-        clipboard.setMimeData(mime)
-        self.log("Wind Spiral parameters (from UI) copied to clipboard as a Word table.")
-        self.iface.messageBar().pushMessage("QPANSOPY", "Wind Spiral parameters copied (from UI)", level=Qgis.Success)
+        from ...parameters_inspector_dialog import ParametersInspectorDialog
+        dialog = ParametersInspectorDialog(
+            "Wind Spiral — Feature Parameters", html_table, text_table, parent=self)
+        dialog.show()
+        self.log("Wind Spiral parameters (from UI) shown in Parameters Inspector.")
 
     def copy_parameters_as_json(self):
         """Copiar los parámetros actuales al portapapeles en formato JSON"""
@@ -643,7 +640,7 @@ class QPANSOPYWindSpiralDockWidgetBase(QtWidgets.QDockWidget, FORM_CLASS):
                     self.log(f"Wind Spiral KML exported to: {result.get('spiral_path', 'N/A')}")
                 self.log("Calculation completed successfully!")
                 self.log(
-                    "You can now use the 'Copy Parameters as JSON' button to copy the parameters for documentation.")
+                    "You can now use the 'Show Table' button to view and copy the parameters for documentation.")
             else:
                 self.log("Calculation completed but no results were returned.")
         except Exception as e:

--- a/Q_Pansopy/metadata.txt
+++ b/Q_Pansopy/metadata.txt
@@ -37,6 +37,7 @@ changelog=
  - Fix Wind Spiral ISA Variation field being silently ignored by the actual calculation
  - Update PBN Target layer style: thinner outline (0.25mm) and add ARP-distance labels
  - Fix Basic ILS missed approach surface lateral half-width formula (was incorrectly using a flat 15% splay instead of the 14.3% transition-slope-derived offset), restoring parity with the reference script
+ - Add a Parameters Inspector: render the stored 'parameters' JSON as an HTML table via a QGIS layer action (Basic ILS, OAS ILS, VSS, Wind Spiral) or the dockwidget's 'Show Table' button (also on Holding and SID Initial Climb), with a Copy to Word option
  Version 0.4.0:
  - Fixes to initial realease to code logic including QGIS Plugin Store Compliance
  - PBN 15 NM and 30 NM targets included

--- a/Q_Pansopy/modules/basic_ils.py
+++ b/Q_Pansopy/modules/basic_ils.py
@@ -17,6 +17,7 @@ import os
 import datetime
 import json
 from ..utils import get_selected_feature, fix_kml_altitude_mode
+from ..parameters_inspector_dialog import register_parameters_action
 from .constants import FT_TO_M, ILS_GROUND_LENGTH_M, ILS_APPROACH_1_M, ILS_SPLAY_RATIO, ILS_TRANSITION_SLOPE
 
 
@@ -321,6 +322,9 @@ def calculate_basic_ils(iface, point_layer, runway_layer, params):
     transition_rule.setFilterExpression("\"ILS_surface\" LIKE 'transition surface%'")
     root_rule.appendChild(transition_rule)
     v_layer.setRenderer(QgsRuleBasedRenderer(root_rule))
+
+    # Let users inspect the stored 'parameters' JSON as a rendered table
+    register_parameters_action(v_layer)
 
     # Add layer to the project
     QgsProject.instance().addMapLayer(v_layer)

--- a/Q_Pansopy/modules/oas_ils.py
+++ b/Q_Pansopy/modules/oas_ils.py
@@ -19,6 +19,7 @@ import json
 import numpy as np
 import re
 from ..utils import get_selected_feature, fix_kml_altitude_mode, fix_kml_polygon_fill_color
+from ..parameters_inspector_dialog import register_parameters_action
 
 # Global variables to store computed values
 OAS_template = None
@@ -344,6 +345,9 @@ def calculate_oas_ils(iface, point_layer, runway_layer, params):
 
         # Update layer extents
         v_layer.updateExtents()
+
+        # Let users inspect the stored 'parameters' JSON as a rendered table
+        register_parameters_action(v_layer)
 
         # Add layer to the project
         QgsProject.instance().addMapLayer(v_layer)

--- a/Q_Pansopy/modules/vss_loc.py
+++ b/Q_Pansopy/modules/vss_loc.py
@@ -16,6 +16,7 @@ import os
 import datetime
 import json
 from ..utils import get_selected_feature, fix_kml_altitude_mode
+from ..parameters_inspector_dialog import register_parameters_action
 from .constants import FT_TO_M
 
 
@@ -205,6 +206,10 @@ def calculate_vss_loc(iface, point_layer, runway_layer, params):
     ocs_layer.renderer().symbol().symbolLayer(0).setStrokeColor(QColor(255, 146, 0))
     ocs_layer.renderer().symbol().symbolLayer(0).setStrokeWidth(0.7)
     ocs_layer.triggerRepaint()
+
+    # Let users inspect the stored 'parameters' JSON as a rendered table
+    register_parameters_action(vss_layer)
+    register_parameters_action(ocs_layer)
 
     # Add layers to the project
     QgsProject.instance().addMapLayers([vss_layer, ocs_layer])

--- a/Q_Pansopy/modules/vss_straight.py
+++ b/Q_Pansopy/modules/vss_straight.py
@@ -16,6 +16,7 @@ import os
 import datetime
 import json
 from ..utils import get_selected_feature, fix_kml_altitude_mode
+from ..parameters_inspector_dialog import register_parameters_action
 from .constants import FT_TO_M
 
 
@@ -202,6 +203,10 @@ def calculate_vss_straight(iface, point_layer, runway_layer, params):
     ocs_layer.renderer().symbol().symbolLayer(0).setStrokeColor(QColor(255, 146, 0))
     ocs_layer.renderer().symbol().symbolLayer(0).setStrokeWidth(0.7)
     ocs_layer.triggerRepaint()
+
+    # Let users inspect the stored 'parameters' JSON as a rendered table
+    register_parameters_action(vss_layer)
+    register_parameters_action(ocs_layer)
 
     # Add layers to the project
     QgsProject.instance().addMapLayers([vss_layer, ocs_layer])

--- a/Q_Pansopy/modules/wind_spiral.py
+++ b/Q_Pansopy/modules/wind_spiral.py
@@ -16,6 +16,7 @@ import os
 import datetime
 import json
 from ..utils import get_selected_feature, fix_kml_altitude_mode
+from ..parameters_inspector_dialog import register_parameters_action
 
 
 def ISA_temperature(adElev, tempRef):
@@ -256,6 +257,9 @@ def calculate_wind_spiral(iface, point_layer, reference_layer, params):
     pv_layer.renderer().symbol().setColor(QColor("green"))
     pv_layer.renderer().symbol().setWidth(0.5)
     pv_layer.triggerRepaint()
+
+    # Let users inspect the stored 'parameters' JSON as a rendered table
+    register_parameters_action(pv_layer)
 
     # Add layers to the project
     QgsProject.instance().addMapLayer(pv_layer)

--- a/Q_Pansopy/parameters_inspector_dialog.py
+++ b/Q_Pansopy/parameters_inspector_dialog.py
@@ -1,0 +1,155 @@
+# -*- coding: utf-8 -*-
+"""
+/***************************************************************************
+Parameters Inspector Dialog
+                            A QGIS plugin
+Renders a feature's 'parameters' JSON attribute as a readable HTML table,
+with a button to copy it to the clipboard as a Word-pasteable table.
+                        -------------------
+   begin                : 2026-07-28
+   copyright            : (C) 2026 by QPANSOPY Team
+***************************************************************************/
+
+/***************************************************************************
+*                                                                         *
+*   This program is free software; you can redistribute it and/or modify  *
+*   it under the terms of the GNU General Public License as published by  *
+*   the Free Software Foundation; either version 2 of the License, or     *
+*   (at your option) any later version.                                   *
+***************************************************************************/
+"""
+import json
+
+from qgis.core import QgsAction, QgsProject
+from qgis.PyQt.QtCore import QMimeData
+from qgis.PyQt.QtWidgets import (
+    QApplication, QDialog, QHBoxLayout, QMessageBox, QPushButton, QTextBrowser, QVBoxLayout,
+)
+
+from .dockwidgets.base_dockwidget import load_base_qss
+from .utils import format_parameters_table
+
+
+def _generic_python_action_type():
+    """
+    QgsAction.GenericPython (Qt5/PyQt5) vs QgsAction.ActionType.GenericPython
+    (Qt6/PyQt6, QGIS 4 scoped enum). Resolved lazily -- not at import time --
+    so importing this module never depends on QgsAction's enum shape (e.g.
+    under the test suite's QGIS stubs, which don't define either).
+    """
+    try:
+        return QgsAction.ActionType.GenericPython
+    except AttributeError:
+        return QgsAction.GenericPython  # type: ignore[attr-defined]
+
+
+# Reached from a QGIS layer action, which is triggered per-click rather than
+# tracked by any caller -- keep non-modal dialogs alive here, otherwise PyQt
+# garbage-collects the QDialog the moment show_parameters_inspector() returns.
+_open_dialogs = []
+
+
+class ParametersInspectorDialog(QDialog):
+    """Read-only popup rendering a feature's stored parameters as an HTML table."""
+
+    def __init__(self, title, html_table, text_table, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle(title)
+        self.setMinimumSize(480, 420)
+        self.setStyleSheet(load_base_qss())
+        self._html_table = html_table
+        self._text_table = text_table
+        self._setup_ui()
+
+    def _setup_ui(self):
+        layout = QVBoxLayout(self)
+
+        browser = QTextBrowser(self)
+        # The dialog's dark QSS (load_base_qss()) styles bare QTextEdit as a
+        # dark log panel (near-black background, light-gray text) -- correct
+        # for the log widgets it was written for, but it also matches
+        # QTextBrowser (a QTextEdit subclass), muddying the table's own
+        # white/light-gray cell backgrounds and leaving text low-contrast.
+        # Override locally so the rendered table stays crisp and readable.
+        browser.setStyleSheet(
+            "QTextBrowser { background-color: #ffffff; color: #202020; border: 1px solid #444; }"
+        )
+        browser.setHtml(self._html_table)
+        layout.addWidget(browser)
+
+        button_row = QHBoxLayout()
+        copy_btn = QPushButton("Copy to Word")
+        copy_btn.clicked.connect(self.copy_to_word)
+        button_row.addWidget(copy_btn)
+        button_row.addStretch()
+        close_btn = QPushButton("Close")
+        close_btn.clicked.connect(self.close)
+        button_row.addWidget(close_btn)
+        layout.addLayout(button_row)
+
+    def copy_to_word(self):
+        mime = QMimeData()
+        mime.setHtml(self._html_table)
+        mime.setText(self._text_table)
+        QApplication.clipboard().setMimeData(mime)
+
+
+def resolve_inspector_title(parameters_dict, fallback):
+    """
+    Pick a readable dialog title: the stored 'calculation_type' if present,
+    else *fallback* (e.g. the layer name).
+    """
+    calculation_type = parameters_dict.get('calculation_type') if isinstance(parameters_dict, dict) else None
+    subject = calculation_type or fallback
+    return f"{subject} — Feature Parameters"
+
+
+def show_parameters_inspector(layer_id, feature_id):
+    """
+    Entry point for the QGIS layer action registered by
+    register_parameters_action(). Resolves the feature's stored 'parameters'
+    JSON and shows it in a ParametersInspectorDialog.
+    """
+    layer = QgsProject.instance().mapLayer(layer_id)
+    if layer is None:
+        QMessageBox.warning(None, "Parameters Inspector", "Could not find the source layer.")
+        return
+
+    feature = layer.getFeature(feature_id)
+    if not feature.isValid():
+        QMessageBox.warning(None, "Parameters Inspector", "Could not find the selected feature.")
+        return
+
+    raw = feature.attribute('parameters')
+    if not raw:
+        QMessageBox.information(None, "Parameters Inspector", "This feature has no stored parameters.")
+        return
+
+    try:
+        parsed = json.loads(raw)
+    except (TypeError, ValueError):
+        QMessageBox.warning(None, "Parameters Inspector", "The stored parameters could not be parsed as JSON.")
+        return
+
+    title = resolve_inspector_title(parsed, layer.name())
+    html_table = format_parameters_table(title, parsed, as_html=True)
+    text_table = format_parameters_table(title, parsed, as_html=False)
+
+    dialog = ParametersInspectorDialog(title, html_table, text_table)
+    _open_dialogs.append(dialog)
+    dialog.finished.connect(lambda _result: _open_dialogs.remove(dialog) if dialog in _open_dialogs else None)
+    dialog.show()
+
+
+def register_parameters_action(layer):
+    """
+    Register a 'Show Parameters' QGIS layer action on *layer*, so any
+    feature with a 'parameters' attribute can be inspected as a rendered
+    HTML table from the Attribute Table / Identify results (issue #193).
+    """
+    action_code = (
+        "from Q_Pansopy.parameters_inspector_dialog import show_parameters_inspector\n"
+        "show_parameters_inspector('[% @layer_id %]', [% $id %])"
+    )
+    action = QgsAction(_generic_python_action_type(), "Show Parameters (QPANSOPY)", action_code)
+    layer.actions().addAction(action)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,7 +35,7 @@ def _install_qgis_stubs():
         'QgsCategorizedSymbolRenderer', 'QgsRendererCategory',
         'QgsSimpleFillSymbolLayer',
         # Map layer
-        'QgsMapLayerProxyModel', 'QgsMapLayerComboBox',
+        'QgsMapLayerProxyModel', 'QgsMapLayerComboBox', 'QgsAction',
         # Additional geometry/query classes
         'QgsRectangle', 'QgsFeatureRequest', 'QgsSpatialIndex',
         'QgsLayerTreeGroup', 'QgsLayerTreeLayer',
@@ -68,6 +68,7 @@ def _install_qgis_stubs():
         'Double': 6, 'QString': 10, 'Int': 2,
     })
     qtcore.pyqtSignal = lambda *a, **kw: None
+    qtcore.QMimeData = _Dummy
     qtgui.QColor = _Dummy
 
     # uic stub — needed by dockwidget modules that call uic.loadUiType()
@@ -80,6 +81,7 @@ def _install_qgis_stubs():
         'QFileDialog', 'QDialog', 'QFormLayout', 'QLineEdit', 'QComboBox',
         'QDialogButtonBox', 'QMessageBox', 'QWidget', 'QApplication',
         'QDockWidget', 'QPushButton', 'QTextEdit', 'QGroupBox', 'QVBoxLayout',
+        'QHBoxLayout', 'QTextBrowser',
     ]:
         setattr(qtwidgets, widget_name, _Dummy)
 

--- a/tests/unit/test_parameters_inspector_dialog.py
+++ b/tests/unit/test_parameters_inspector_dialog.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for issue #193: registering the 'Show Parameters' QGIS layer action and
+resolving a readable dialog title from the stored 'parameters' JSON.
+"""
+import importlib
+
+
+def _mod():
+    return importlib.import_module('Q_Pansopy.parameters_inspector_dialog')
+
+
+# ---------------------------------------------------------------------------
+# resolve_inspector_title
+# ---------------------------------------------------------------------------
+
+def test_title_uses_calculation_type_when_present():
+    mod = _mod()
+    title = mod.resolve_inspector_title({'calculation_type': 'Basic ILS'}, fallback='My Layer')
+    assert title == 'Basic ILS — Feature Parameters'
+
+
+def test_title_falls_back_to_layer_name_when_missing():
+    mod = _mod()
+    title = mod.resolve_inspector_title({}, fallback='My Layer')
+    assert title == 'My Layer — Feature Parameters'
+
+
+def test_title_falls_back_for_non_dict_input():
+    mod = _mod()
+    title = mod.resolve_inspector_title(None, fallback='My Layer')
+    assert title == 'My Layer — Feature Parameters'
+
+
+# ---------------------------------------------------------------------------
+# register_parameters_action
+# ---------------------------------------------------------------------------
+
+class _FakeActions:
+    def __init__(self):
+        self.added = []
+
+    def addAction(self, action):
+        self.added.append(action)
+
+
+class _FakeLayer:
+    def __init__(self):
+        self._actions = _FakeActions()
+
+    def actions(self):
+        return self._actions
+
+
+def test_register_parameters_action_uses_safe_substitution_tokens(monkeypatch):
+    """
+    Regression guard: the action code must resolve the feature via
+    '[% @layer_id %]' / '[% $id %]' substitution (safe, quote-free) rather
+    than interpolating the raw JSON string, which could contain characters
+    that break the generated Python literal.
+    """
+    mod = _mod()
+
+    captured = {}
+
+    class _FakeQgsAction:
+        GenericPython = 'generic-python'
+
+        def __init__(self, action_type, name, action_code):
+            captured['action_type'] = action_type
+            captured['name'] = name
+            captured['action_code'] = action_code
+
+    monkeypatch.setattr(mod, 'QgsAction', _FakeQgsAction)
+
+    layer = _FakeLayer()
+    mod.register_parameters_action(layer)
+
+    assert len(layer._actions.added) == 1
+    code = captured['action_code']
+    assert 'show_parameters_inspector' in code
+    assert '@layer_id' in code
+    assert '$id' in code
+    # Never interpolate the raw parameters JSON directly into the action code.
+    assert '"parameters"' not in code


### PR DESCRIPTION
# PR — Render parameter field as HTML action (Issue #193)

## Summary

- New **Parameters Inspector** popup: renders any feature's stored `parameters` JSON as a
  readable HTML table, with a "Copy to Word" button.
- Reachable two ways:
  - A QGIS layer action ("Show Parameters (QPANSOPY)") registered on every layer the plugin
    creates with a `parameters` field (Basic ILS, OAS ILS, VSS, Wind Spiral) — works on any
    feature at any time via the Attribute Table / Identify results.
  - Each affected dockwidget's former "Copy for Word" button now says **"Show Table"** and opens
    the same popup immediately after a calculation, instead of silently copying to the clipboard.
    The clipboard copy now happens from inside the popup. This includes Holding and SID Initial
    Climb, whose parameters come from the current calculation summary/UI values (not a stored
    layer field, since those modules don't produce a `parameters` attribute).
<img width="480" height="585" alt="swappy-20260728-013713" src="https://github.com/user-attachments/assets/d188472b-97a4-4786-a8e7-430928d725c3" />
<img width="418" height="602" alt="swappy-20260728-013732" src="https://github.com/user-attachments/assets/cf467735-29f1-4076-bbbb-acd58c40ab38" />

## Root cause / motivation

The `parameters` JSON stored on output features was only readable via the raw attribute table —
hard to parse for end users. The reporter's own mockup showed a dedicated "Parameters Inspector"
view; per follow-up direction, the existing per-tool "Copy for Word" buttons were repurposed to
open that view directly rather than adding a second, separate access path.

## Implementation notes

- `Q_Pansopy/parameters_inspector_dialog.py` (new) centralizes the dialog, the QGIS-action
  registration, and the JSON→title resolution. Reuses `Q_Pansopy/utils.py::format_parameters_table`
  (already used for every module's existing "Copy Parameters" logic) as the single source of
  truth for both the on-screen table and the Word-clipboard content — no new HTML/CSS template.
- The QGIS action never interpolates the raw `parameters` JSON string into the generated Python
  action code (which could contain characters that break the generated literal) — it passes only
  `@layer_id`/`$id` and resolves the feature in Python.
- `QgsAction.GenericPython` (Qt5) vs. `QgsAction.ActionType.GenericPython` (Qt6/QGIS 4 scoped
  enum) is resolved lazily inside `register_parameters_action`, not at import time, following the
  same `try/except AttributeError` pattern already used throughout `qt_compat.py` for other
  QGIS-4 scoped-enum differences.
- `tests/conftest.py`'s QGIS/Qt stubs were missing `QgsAction`, `QMimeData`, `QHBoxLayout`, and
  `QTextBrowser` — added so the module tree stays importable under the test suite.
- The dialog's `QTextBrowser` initially rendered the table looking washed-out/low-contrast: the
  app-wide dark QSS (`load_base_qss()`) styles bare `QTextEdit` (which `QTextBrowser` subclasses)
  as a near-black log panel with light-gray text, and `format_parameters_table`'s HTML only sets
  cell *background* colors, not text color, so cells inherited that light-gray-on-white text.
  Fixed with a local stylesheet override on the browser widget (white background, dark text).

## Files Modified

| File | Change |
|---|---|
| `Q_Pansopy/parameters_inspector_dialog.py` | New: dialog, action registration, title resolution |
| `Q_Pansopy/modules/basic_ils.py`, `oas_ils.py`, `vss_straight.py`, `vss_loc.py`, `wind_spiral.py` | `register_parameters_action(layer)` wired in before each layer is added to the project |
| `Q_Pansopy/dockwidgets/utilities/qpansopy_wind_spiral_dockwidget.py` | "Copy for Word" → "Show Table"; also fixed a button mislabeled "Copy Parameters as JSON" |
| `Q_Pansopy/dockwidgets/ils/qpansopy_ils_dockwidget.py` | "Copy for Word" → "Show Table" |
| `Q_Pansopy/dockwidgets/ils/qpansopy_oas_ils_dockwidget.py` | "Copy for Word" → "Show Table" |
| `Q_Pansopy/dockwidgets/utilities/qpansopy_vss_dockwidget.py` | "Copy for Word" → "Show Table" |
| `Q_Pansopy/dockwidgets/utilities/qpansopy_holding_dockwidget.py` | "Copy for Word" → "Show Table" |
| `Q_Pansopy/dockwidgets/departures/qpansopy_sid_initial_dockwidget.py` | "Copy for Word" → "Show Table" |
| `tests/conftest.py` | Added missing QGIS/Qt stubs |
| `tests/unit/test_parameters_inspector_dialog.py` | New tests |
| `Q_Pansopy/metadata.txt` | Changelog bullet |
| `docs/plan-193.md` | Implementation plan |

## Test plan

- [x] `pytest tests/ -q` — no regressions, new tests pass.
- [x] `flake8`/`bandit` on all touched files — 0 findings (pre-existing unrelated findings in a
  few dockwidgets untouched).
- [ ] In QGIS: run each of the 5 tools, open the output layer's Attribute Table, confirm the
  action icon and that it opens a readable table.
- [ ] Click each affected dockwidget's "Show Table" button right after calculating; confirm the
  popup opens with that run's parameters.
- [ ] "Copy to Word" from the popup pastes correctly into a Word document.

## Related

Closes #193.
