### PR TITLE
Parameters Inspector follow-up (Issue #193, reopened)

### DIFF
--- a/Q_Pansopy/dockwidgets/departures/qpansopy_sid_initial_dockwidget.py
+++ b/Q_Pansopy/dockwidgets/departures/qpansopy_sid_initial_dockwidget.py
@@ -141,48 +141,11 @@ class QPANSOPYSIDInitialDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         The popup itself offers a 'Copy to Word' button (issue #193)."""
         params = self.get_parameters()
 
-        param_list = [
-            ('Aerodrome Elevation', params['aerodrome_elevation_m'], 'm'),
-            ('DER Elevation', params['der_elevation_m'], 'm'),
-            ('PDG', params['pdg_percent'], '%'),
-            ('Reference Temperature', params['reference_temp_c'], '°C'),
-            ('IAS', params['ias_kt'], 'kt'),
-            ('Turn Altitude', params['altitude_ft'], 'ft'),
-            ('Bank Angle', params['bank_angle_deg'], '°'),
-            ('Wind Speed', params['wind_kt'], 'kt'),
-            ('Pilot Reaction Time', params['pilot_time_s'], 's'),
-            ('Direction', 'End → Start' if self.direction_reversed else 'Start → End', '')
-        ]
+        flat_params = dict(params)
+        flat_params['direction'] = 'End → Start' if self.direction_reversed else 'Start → End'
 
-        # Create HTML table
-        html = '<table border="1" cellpadding="5" cellspacing="0" style="border-collapse: collapse;">\n'
-        html += (
-            '<tr><th colspan="3" style="background-color: #4472C4; color: white; '
-            'text-align: center; font-weight: bold;">SID INITIAL CLIMB CALCULATION PARAMETERS</th></tr>\n'
-        )
-        html += (
-            '<tr style="background-color: #D9E1F2; font-weight: bold;">'
-            '<th>PARAMETER</th><th>VALUE</th><th>UNIT</th></tr>\n'
-        )
-
-        for i, (name, value, unit) in enumerate(param_list):
-            bg_color = '#FFFFFF' if i % 2 == 0 else '#F2F2F2'
-            html += (
-                f'<tr style="background-color: {bg_color};">'
-                f'<td>{name}</td><td style="text-align: right;">{value}</td><td>{unit}</td></tr>\n'
-            )
-
-        html += '</table>'
-
-        plain_text = "SID INITIAL CLIMB CALCULATION PARAMETERS\n"
-        plain_text += "=" * 50 + "\n\n"
-        for name, value, unit in param_list:
-            plain_text += f"{name}\t{value}\t{unit}\n"
-
-        from ...parameters_inspector_dialog import ParametersInspectorDialog
-        dialog = ParametersInspectorDialog(
-            "SID Initial Climb — Feature Parameters", html, plain_text, parent=self)
-        dialog.show()
+        from ...parameters_inspector_dialog import show_web_popup
+        show_web_popup("SID Initial Climb — Feature Parameters", [("SID Initial Climb", flat_params)])
         self.log("SID Initial parameters shown in Parameters Inspector.")
 
     def copy_parameters_as_json(self):

--- a/Q_Pansopy/dockwidgets/ils/qpansopy_ils_dockwidget.py
+++ b/Q_Pansopy/dockwidgets/ils/qpansopy_ils_dockwidget.py
@@ -24,13 +24,11 @@ Procedure Analysis and Obstacle Protection Surfaces - ILS Module
 import os
 import json
 import datetime
-from collections import OrderedDict
 from qgis.PyQt import QtWidgets, uic
 from qgis.PyQt.QtCore import pyqtSignal, QRegularExpression, QMimeData
 from qgis.PyQt.QtGui import QRegularExpressionValidator
 from qgis.core import QgsProject, QgsVectorLayer
 from qgis.core import Qgis
-from ...utils import format_parameters_table
 from ...qt_compat import DOCK_FEATURES_DEFAULT, FORM_FIELD_ROLE, Qt_ALLOWED_DOCK_AREAS, MLPM_PointLayer, MLPM_LineLayer, preseed_active_layer, Qgis_GeomType_Line
 
 # Use __file__ to get the current script path
@@ -198,14 +196,13 @@ class QPANSOPYILSDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
 
    def show_parameters_table(self):
        """Mostrar los parámetros como una tabla HTML, con opción de copiar a Word"""
+       from ...parameters_inspector_dialog import show_web_popup
+
        layers = QgsProject.instance().mapLayers().values()
        vector_layers = [layer for layer in layers if isinstance(layer, QgsVectorLayer)]
-       params_text = ""
-       html_blocks = []
-       found_params = False
+       sections = []
 
        for layer in vector_layers:
-           has_ils_params = False
            if 'parameters' not in [field.name() for field in layer.fields()]:
                continue
 
@@ -221,59 +218,19 @@ class QPANSOPYILSDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
 
                calculation_type = params_dict.get('calculation_type', '')
                if calculation_type and 'Basic ILS' in calculation_type:
-                   has_ils_params = True
-                   layer_params = OrderedDict()
-                   layer_sections = {}
-
-                   thr_value = params_dict.get('thr_elev', '')
-                   thr_unit = params_dict.get('thr_elev_unit', 'm')
-                   layer_params['thr_elev'] = {'value': thr_value, 'unit': thr_unit}
-                   layer_sections['thr_elev'] = 'Runway Data'
-
-                   layer_params['calculation_date'] = {'value': params_dict.get('calculation_date', ''), 'unit': ''}
-                   layer_sections['calculation_date'] = 'Calculation Info'
-
-                   layer_params['calculation_type'] = {'value': calculation_type, 'unit': ''}
-                   layer_sections['calculation_type'] = 'Calculation Info'
-
+                   layer_params = dict(params_dict)
                    if 'ILS_surface' in [field.name() for field in layer.fields()]:
-                       surface_type = feature.attribute('ILS_surface') or ''
-                       layer_params['surface_type'] = {'value': surface_type, 'unit': ''}
-                       layer_sections['surface_type'] = 'Surface Information'
-
-                   formatted_table_html = format_parameters_table(
-                       "QPANSOPY BASIC ILS PARAMETERS",
-                       layer_params,
-                       layer_sections,
-                       as_html=True
-                   )
-                   formatted_table_text = format_parameters_table(
-                       "QPANSOPY BASIC ILS PARAMETERS",
-                       layer_params,
-                       layer_sections,
-                       as_html=False
-                   )
-
-                   params_text += f"LAYER: {layer.name()}\n{'-'*30}\n"
-                   params_text += formatted_table_text + "\n"
-                   html_blocks.append(f"<h3>LAYER: {layer.name()}</h3>{formatted_table_html}")
-                   found_params = True
+                       layer_params['surface_type'] = feature.attribute('ILS_surface') or ''
+                   sections.append((layer.name(), layer_params))
                    break
 
-           if has_ils_params:
-               params_text += "\n"
+       if not sections:
+           sections = [(
+               "No data",
+               {'message': 'No Basic ILS parameters found in any layer. Please run a calculation first.'}
+           )]
 
-       if not found_params:
-           params_text += "QPANSOPY BASIC ILS CALCULATION PARAMETERS\n"
-           params_text += "=" * 50 + "\n\n"
-           params_text += "No Basic ILS parameters found in any layer. Please run a calculation first.\n"
-           html_blocks.append("<p>No Basic ILS parameters found in any layer. Please run a calculation first.</p>")
-
-       from ...parameters_inspector_dialog import ParametersInspectorDialog
-       html_table = "<div>" + "<br>".join(html_blocks) + "</div>"
-       dialog = ParametersInspectorDialog(
-           "Basic ILS — Feature Parameters", html_table, params_text, parent=self)
-       dialog.show()
+       show_web_popup("Basic ILS — Feature Parameters", sections)
        self.log("Basic ILS parameters shown in Parameters Inspector.")
 
    def copy_parameters_as_json(self):

--- a/Q_Pansopy/dockwidgets/ils/qpansopy_oas_ils_dockwidget.py
+++ b/Q_Pansopy/dockwidgets/ils/qpansopy_oas_ils_dockwidget.py
@@ -169,82 +169,37 @@ class QPANSOPYOASILSDockWidgetBase(QtWidgets.QDockWidget, FORM_CLASS):
 
    def show_parameters_table(self):
        """Mostrar los parámetros OAS ILS como una tabla HTML, con opción de copiar a Word"""
-       from ...utils import format_parameters_table
+       from ...parameters_inspector_dialog import show_web_popup
 
        layers = QgsProject.instance().mapLayers().values()
        vector_layers = [layer for layer in layers if isinstance(layer, QgsVectorLayer)]
-       html_chunks = []
-       text_chunks = []
-       found_params = False
+       sections = []
 
        for layer in vector_layers:
-           has_oas_params = False
-           if 'parameters' in [field.name() for field in layer.fields()]:
-               for feature in layer.getFeatures():
-                   params_json = feature.attribute('parameters')
-                   if params_json:
-                       try:
-                           params_dict = json.loads(params_json)
-                           if 'calculation_type' in params_dict and 'OAS ILS' in params_dict['calculation_type']:
-                               has_oas_params = True
-                               # Build table data
-                               layer_params = {}
-                               layer_sections = {}
-                               thr_value = params_dict.get('THR_elev', '')
-                               thr_unit = params_dict.get('THR_elev_unit', 'm')
-                               layer_params['THR_elev'] = {'value': thr_value, 'unit': thr_unit}
-                               layer_sections['THR_elev'] = 'Runway Data'
-
-                               layer_params['FAP_elev'] = {'value': params_dict.get('FAP_elev', ''), 'unit': 'ft'}
-                               layer_sections['FAP_elev'] = 'Calculation Inputs'
-
-                               layer_params['MOC_intermediate'] = {'value': params_dict.get('MOC_intermediate', ''), 'unit': 'm'}
-                               layer_sections['MOC_intermediate'] = 'Calculation Inputs'
-
-                               layer_params['calculation_date'] = {'value': params_dict.get('calculation_date', ''), 'unit': ''}
-                               layer_sections['calculation_date'] = 'Calculation Info'
-
-                               layer_params['calculation_type'] = {'value': params_dict.get('calculation_type', ''), 'unit': ''}
-                               layer_sections['calculation_type'] = 'Calculation Info'
-
-                               if 'ILS_surface' in [field.name() for field in layer.fields()]:
-                                   surface_type = feature.attribute('ILS_surface') or ''
-                                   layer_params['surface_type'] = {'value': surface_type, 'unit': ''}
-                                   layer_sections['surface_type'] = 'Surface Information'
-
-                               table_html = format_parameters_table(
-                                   "QPANSOPY OAS ILS PARAMETERS",
-                                   layer_params,
-                                   layer_sections,
-                                   as_html=True
-                               )
-                               text_table = format_parameters_table(
-                                   "QPANSOPY OAS ILS PARAMETERS",
-                                   layer_params,
-                                   layer_sections,
-                                   as_html=False
-                               )
-                               html_chunks.append(f"<h3>LAYER: {layer.name()}</h3>" + table_html)
-                               text_chunks.append(f"LAYER: {layer.name()}\n{text_table}")
-                               found_params = True
-                               break
-                       except Exception:
-                           pass
-
-           if has_oas_params:
+           if 'parameters' not in [field.name() for field in layer.fields()]:
                continue
+           for feature in layer.getFeatures():
+               params_json = feature.attribute('parameters')
+               if not params_json:
+                   continue
+               try:
+                   params_dict = json.loads(params_json)
+               except Exception:
+                   continue
+               if 'calculation_type' in params_dict and 'OAS ILS' in params_dict['calculation_type']:
+                   layer_params = dict(params_dict)
+                   if 'ILS_surface' in [field.name() for field in layer.fields()]:
+                       layer_params['surface_type'] = feature.attribute('ILS_surface') or ''
+                   sections.append((layer.name(), layer_params))
+                   break
 
-       if not found_params:
-           html_chunks.append("<p>No OAS ILS parameters found in any layer. Please run a calculation first.</p>")
-           text_chunks.append("No OAS ILS parameters found in any layer. Please run a calculation first.")
+       if not sections:
+           sections = [(
+               "No data",
+               {'message': 'No OAS ILS parameters found in any layer. Please run a calculation first.'}
+           )]
 
-       html_content = "<div>" + "<br>".join(html_chunks) + "</div>"
-       plain_content = "\n\n".join(text_chunks)
-
-       from ...parameters_inspector_dialog import ParametersInspectorDialog
-       dialog = ParametersInspectorDialog(
-           "OAS ILS — Feature Parameters", html_content, plain_content, parent=self)
-       dialog.show()
+       show_web_popup("OAS ILS — Feature Parameters", sections)
        self.log("OAS ILS parameters shown in Parameters Inspector.")
 
    def copy_parameters_as_json(self):

--- a/Q_Pansopy/dockwidgets/utilities/qpansopy_holding_dockwidget.py
+++ b/Q_Pansopy/dockwidgets/utilities/qpansopy_holding_dockwidget.py
@@ -109,34 +109,19 @@ class QPANSOPYHoldingDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
             self.log('Error: No calculation available to show')
             return
 
-        rows = [
-            ("IAS", f"{summary.get('IAS_kt', 0):.1f}", "kt"),
-            ("Altitude", f"{summary.get('Altitude_ft', 0):.0f}", "ft"),
-            ("ISA Delta", f"{summary.get('ISA_var_C', 0):.1f}", "°C"),
-            ("Bank Angle", f"{summary.get('Bank_deg', 0):.1f}", "deg"),
-            ("Leg Time", f"{summary.get('Leg_min', 0):.2f}", "min"),
-            ("Leg Length", f"{summary.get('Leg_nm', 0):.2f}", "NM"),
-            ("Turn", f"{summary.get('Turn', '')}", ""),
-            ("TAS", f"{summary.get('TAS_kt', 0):.2f}", "kt"),
-            ("Rate of Turn", f"{summary.get('Rate_deg_s', 0):.3f}", "°/s"),
-            ("Radius", f"{summary.get('Radius_nm', 0):.3f}", "NM"),
-        ]
+        flat_params = {
+            'IAS_kt': f"{summary.get('IAS_kt', 0):.1f}",
+            'Altitude_ft': f"{summary.get('Altitude_ft', 0):.0f}",
+            'ISA_var_C': f"{summary.get('ISA_var_C', 0):.1f}",
+            'Bank_deg': f"{summary.get('Bank_deg', 0):.1f}",
+            'Leg_min': f"{summary.get('Leg_min', 0):.2f}",
+            'Leg_nm': f"{summary.get('Leg_nm', 0):.2f}",
+            'Turn': summary.get('Turn', ''),
+            'TAS_kt': f"{summary.get('TAS_kt', 0):.2f}",
+            'Rate_deg_s': f"{summary.get('Rate_deg_s', 0):.3f}",
+            'Radius_nm': f"{summary.get('Radius_nm', 0):.3f}",
+        }
 
-        # Build tab-delimited text (fallback) and HTML table (for Word)
-        lines = ["Parameter\tValue\tUnits"]
-        for p, v, u in rows:
-            lines.append(f"{p}\t{v}\t{u}")
-        table_text = "\n".join(lines)
-
-        html_rows = ["<table border='1' cellpadding='4' cellspacing='0' style='border-collapse:collapse;'>",
-                     "<tr><th>Parameter</th><th>Value</th><th>Units</th></tr>"]
-        for p, v, u in rows:
-            html_rows.append(f"<tr><td>{p}</td><td style='text-align:right'>{v}</td><td>{u}</td></tr>")
-        html_rows.append("</table>")
-        html_table = "".join(html_rows)
-
-        from ...parameters_inspector_dialog import ParametersInspectorDialog
-        dialog = ParametersInspectorDialog(
-            "Holding Pattern — Feature Parameters", html_table, table_text, parent=self)
-        dialog.show()
+        from ...parameters_inspector_dialog import show_web_popup
+        show_web_popup("Holding Pattern — Feature Parameters", [("Holding Pattern", flat_params)])
         self.log('Holding pattern parameters shown in Parameters Inspector.')

--- a/Q_Pansopy/dockwidgets/utilities/qpansopy_vss_dockwidget.py
+++ b/Q_Pansopy/dockwidgets/utilities/qpansopy_vss_dockwidget.py
@@ -29,7 +29,6 @@ from qgis.core import Qgis
 from ...qt_compat import DOCK_FEATURES_DEFAULT, FORM_FIELD_ROLE, Qt_ALLOWED_DOCK_AREAS, MLPM_PointLayer, MLPM_LineLayer, preseed_active_layer, Qgis_GeomType_Line
 import json
 import datetime
-from ...utils import format_parameters_table
 
 # Use __file__ to get the current script path
 FORM_CLASS, _ = uic.loadUiType(os.path.join(
@@ -131,51 +130,21 @@ class QPANSOPYVSSDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
 
     def show_parameters_table(self):
         """Mostrar los parámetros VSS como una tabla HTML, con opción de copiar a Word"""
-        params = {
-            'runway_details': {
-                'rwy_width': {'value': self.exact_values.get('rwy_width', self.rwyWidthLineEdit.text()), 'unit': 'm'},
-                'thr_elev': {
-                    'value': self.exact_values.get('thr_elev', self.thrElevLineEdit.text()),
-                    'unit': self.units.get('thr_elev', 'm')},
-                'strip_width': {
-                    'value': self.exact_values.get('strip_width', self.stripWidthLineEdit.text()),
-                    'unit': 'm'}
-            },
-            'approach_params': {
-                'OCH': {'value': self.exact_values.get('OCH', self.OCHLineEdit.text()),
-                        'unit': self.units.get('OCH', 'm')},
-                'RDH': {'value': self.exact_values.get('RDH', self.RDHLineEdit.text()),
-                        'unit': self.units.get('RDH', 'm')},
-                'VPA': {'value': self.exact_values.get('VPA', self.VPALineEdit.text()), 'unit': '°'}
-            }
+        from ...parameters_inspector_dialog import show_web_popup
+
+        flat_params = {
+            'rwy_width': self.exact_values.get('rwy_width', self.rwyWidthLineEdit.text()),
+            'thr_elev': self.exact_values.get('thr_elev', self.thrElevLineEdit.text()),
+            'thr_elev_unit': self.units.get('thr_elev', 'm'),
+            'strip_width': self.exact_values.get('strip_width', self.stripWidthLineEdit.text()),
+            'OCH': self.exact_values.get('OCH', self.OCHLineEdit.text()),
+            'OCH_unit': self.units.get('OCH', 'm'),
+            'RDH': self.exact_values.get('RDH', self.RDHLineEdit.text()),
+            'RDH_unit': self.units.get('RDH', 'm'),
+            'VPA': self.exact_values.get('VPA', self.VPALineEdit.text()),
         }
 
-        sections = {
-            'rwy_width': 'Runway Data',
-            'thr_elev': 'Runway Data',
-            'strip_width': 'Runway Data',
-            'OCH': 'Approach Parameters',
-            'RDH': 'Approach Parameters',
-            'VPA': 'Approach Parameters'
-        }
-
-        html_table = format_parameters_table(
-            "QPANSOPY VSS PARAMETERS",
-            params,
-            sections,
-            as_html=True
-        )
-        text_table = format_parameters_table(
-            "QPANSOPY VSS PARAMETERS",
-            params,
-            sections,
-            as_html=False
-        )
-
-        from ...parameters_inspector_dialog import ParametersInspectorDialog
-        dialog = ParametersInspectorDialog(
-            "VSS — Feature Parameters", html_table, text_table, parent=self)
-        dialog.show()
+        show_web_popup("VSS — Feature Parameters", [("VSS", flat_params)])
         self.log("VSS parameters shown in Parameters Inspector.")
 
     def copy_parameters_as_json(self):

--- a/Q_Pansopy/dockwidgets/utilities/qpansopy_wind_spiral_dockwidget.py
+++ b/Q_Pansopy/dockwidgets/utilities/qpansopy_wind_spiral_dockwidget.py
@@ -319,6 +319,8 @@ class QPANSOPYWindSpiralDockWidgetBase(QtWidgets.QDockWidget, FORM_CLASS):
         Prefers reading from output layer 'parameters' JSON; falls back to current UI values.
         The popup itself offers a 'Copy to Word' button (issue #193).
         """
+        from ...parameters_inspector_dialog import show_web_popup
+
         # Try reading from output layers first
         try:
             layers = QgsProject.instance().mapLayers().values()
@@ -349,13 +351,7 @@ class QPANSOPYWindSpiralDockWidgetBase(QtWidgets.QDockWidget, FORM_CLASS):
                         'w': float(data.get('w', 30) or 30),
                         'turn_direction': data.get('turn_direction', 'R')
                     }
-                    from ...modules.wind_spiral import copy_parameters_table
-                    from ...parameters_inspector_dialog import ParametersInspectorDialog
-                    html_table = copy_parameters_table(mapped, as_html=True)
-                    text_table = copy_parameters_table(mapped, as_html=False)
-                    dialog = ParametersInspectorDialog(
-                        "Wind Spiral — Feature Parameters", html_table, text_table, parent=self)
-                    dialog.show()
+                    show_web_popup("Wind Spiral — Feature Parameters", [("Wind Spiral", mapped)])
                     self.log("Wind Spiral parameters (from layer) shown in Parameters Inspector.")
                     return
         except Exception as e:
@@ -373,31 +369,7 @@ class QPANSOPYWindSpiralDockWidgetBase(QtWidgets.QDockWidget, FORM_CLASS):
             'w': self.exact_values.get('w', self.windSpeedLineEdit.text()),
             'turn_direction': self.turnDirectionCombo.currentText()
         }
-        try:
-            from ...modules.wind_spiral import copy_parameters_table
-            html_table = copy_parameters_table(params, as_html=True)
-            text_table = copy_parameters_table(params, as_html=False)
-        except Exception:
-            # Minimal fallback formatting if utils-based table fails
-            text_table = "QPANSOPY WIND SPIRAL CALCULATION PARAMETERS\n" + "=" * 50 + "\n\n"
-            text_table += "PARAMETER\t\t\tVALUE\t\tUNIT\n" + "-" * 50 + "\n"
-            rows = [
-                ("ISA Variation", params['isaVar'], "°C"),
-                ("ISA Source", "Calculated" if params['isa_source'] == 'calculated' else "Manual input", ""),
-                ("IAS", params['IAS'], "kt"),
-                ("Altitude", params['altitude'], params['altitude_unit']),
-                ("Bank Angle", params['bankAngle'], "°"),
-                ("Wind Speed", params['w'], "kt"),
-                ("Turn Direction", params['turn_direction'], ""),
-            ]
-            for name, value, unit in rows:
-                text_table += f"{name:<25}\t{value}\t\t{unit}\n"
-            html_table = text_table.replace("\n", "<br>")
-
-        from ...parameters_inspector_dialog import ParametersInspectorDialog
-        dialog = ParametersInspectorDialog(
-            "Wind Spiral — Feature Parameters", html_table, text_table, parent=self)
-        dialog.show()
+        show_web_popup("Wind Spiral — Feature Parameters", [("Wind Spiral", params)])
         self.log("Wind Spiral parameters (from UI) shown in Parameters Inspector.")
 
     def copy_parameters_as_json(self):

--- a/Q_Pansopy/metadata.txt
+++ b/Q_Pansopy/metadata.txt
@@ -38,6 +38,7 @@ changelog=
  - Update PBN Target layer style: thinner outline (0.25mm) and add ARP-distance labels
  - Fix Basic ILS missed approach surface lateral half-width formula (was incorrectly using a flat 15% splay instead of the 14.3% transition-slope-derived offset), restoring parity with the reference script
  - Store all input parameters (DER elevation, PDG, TNA, MSA, CWY distance, options) as a JSON 'parameters' field on every OMNI SID output feature (areas, reference line, construction points)
+ - Parameters Inspector follow-up: rename the layer action to 'view parameters as HTML Table', fix it not appearing until Feature/Canvas action scopes were manually enabled, and switch the popup (and dockwidget 'Show Table' buttons) to a themeable dark-by-default HTML view with a working light/dark toggle, with a QTextBrowser fallback (including its own native light/dark toggle button) when the optional QtWebEngine Qt bindings aren't installed
  Version 0.4.0:
  - Fixes to initial realease to code logic including QGIS Plugin Store Compliance
  - PBN 15 NM and 30 NM targets included

--- a/Q_Pansopy/parameters_inspector_dialog.py
+++ b/Q_Pansopy/parameters_inspector_dialog.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 """
 /***************************************************************************
-Parameters Inspector Dialog
+Parameters Inspector
                             A QGIS plugin
-Renders a feature's 'parameters' JSON attribute as a readable HTML table,
+Renders a feature's 'parameters' JSON attribute as a readable, themeable
+HTML table (QWebEngineView when available, with a QTextBrowser fallback),
 with a button to copy it to the clipboard as a Word-pasteable table.
                         -------------------
    begin                : 2026-07-28
@@ -18,16 +19,31 @@ with a button to copy it to the clipboard as a Word-pasteable table.
 *   (at your option) any later version.                                   *
 ***************************************************************************/
 """
+import html
 import json
 
 from qgis.core import QgsAction, QgsProject
-from qgis.PyQt.QtCore import QMimeData
+from qgis.PyQt.QtCore import QMimeData, QObject, pyqtSlot
 from qgis.PyQt.QtWidgets import (
-    QApplication, QDialog, QHBoxLayout, QMessageBox, QPushButton, QTextBrowser, QVBoxLayout,
+    QApplication, QDialog, QHBoxLayout, QLabel, QMessageBox, QPushButton, QTextBrowser, QVBoxLayout,
 )
 
-from .dockwidgets.base_dockwidget import load_base_qss
 from .utils import format_parameters_table
+
+# QtWebEngineWidgets/QtWebChannel are optional, heavy Qt components (bundled
+# separately from base PyQt -- e.g. `python-pyqt6-webengine` on Arch/CachyOS)
+# that aren't guaranteed to be installed alongside QGIS. Fall back to a
+# QTextBrowser-based popup (no live JS theme toggle, but still dark by
+# default) rather than crashing every "Show Table" action for users who
+# lack them.
+try:
+    from qgis.PyQt.QtWebChannel import QWebChannel
+    from qgis.PyQt.QtWebEngineWidgets import QWebEngineView
+    _WEBENGINE_AVAILABLE = True
+except ImportError:
+    QWebChannel = None
+    QWebEngineView = None
+    _WEBENGINE_AVAILABLE = False
 
 
 def _generic_python_action_type():
@@ -44,59 +60,381 @@ def _generic_python_action_type():
 
 
 # Reached from a QGIS layer action, which is triggered per-click rather than
-# tracked by any caller -- keep non-modal dialogs alive here, otherwise PyQt
-# garbage-collects the QDialog the moment show_parameters_inspector() returns.
-_open_dialogs = []
+# tracked by any caller -- keep open QWebEngineView popups alive here (keyed
+# by id(view)), otherwise PyQt garbage-collects them the moment
+# show_parameters_inspector()/show_web_popup() returns.
+_open_views = {}
+
+_PAGE_TEMPLATE = """<html>
+<head>
+<style>
+    html, body {
+        font-family: 'Segoe UI', -apple-system, BlinkMacSystemFont, Roboto, sans-serif;
+        margin: 0; padding: 0; height: 100vh;
+        overflow-x: hidden; overflow-y: auto; box-sizing: border-box;
+        transition: background-color 0.2s, color 0.2s;
+    }
+    ::-webkit-scrollbar { width: 14px; background-color: rgba(0, 0, 0, 0.05); }
+    ::-webkit-scrollbar-track { background-color: rgba(0, 0, 0, 0.1); border-radius: 4px; }
+    .light-theme ::-webkit-scrollbar-thumb { background-color: #64748b; border: 2px solid #f4f6f9; border-radius: 6px; }
+    .dark-theme ::-webkit-scrollbar-thumb { background-color: #38bdf8; border: 2px solid #0f172a; border-radius: 6px; }
+    ::-webkit-scrollbar-thumb:hover { background-color: #0076a3 !important; }
+    .dark-theme ::-webkit-scrollbar-thumb:hover { background-color: #f8fafc !important; }
+
+    body.light-theme { background-color: #f4f6f9; color: #333333; }
+    .light-theme .layer-title { color: #1e293b; }
+    .light-theme h3 { color: #1e293b; border-bottom: 2px solid #e2e8f0; }
+    .light-theme .section-title { color: #475569; }
+    .light-theme .table-card { background: #ffffff; border: 1px solid #e2e8f0; box-shadow: 0 4px 6px -1px rgba(0,0,0,0.1); }
+    .light-theme th { background-color: #0f172a; color: #ffffff; border-bottom: 2px solid #1e293b; }
+    .light-theme td { border-bottom: 1px solid #f1f5f9; color: #475569; }
+    .light-theme tr:nth-child(even) td { background-color: #f8fafc; }
+    .light-theme tr:hover td { background-color: #f1f5f9; color: #0f172a; }
+    .light-theme td b { color: #1e293b; }
+    .light-theme .word-btn { background-color: #ffffff; border: 1px solid #cbd5e1; color: #1e293b; }
+    .light-theme .word-btn:hover { background-color: #f1f5f9; }
+
+    body.dark-theme { background-color: #0f172a; color: #cbd5e1; }
+    .dark-theme .layer-title { color: #f8fafc; }
+    .dark-theme h3 { color: #f8fafc; border-bottom: 2px solid #1e293b; }
+    .dark-theme .section-title { color: #94a3b8; }
+    .dark-theme .table-card { background: #1e293b; border: 1px solid #334155; box-shadow: 0 4px 6px -1px rgba(0,0,0,0.3); }
+    .dark-theme th { background-color: #020617; color: #38bdf8; border-bottom: 2px solid #334155; }
+    .dark-theme td { border-bottom: 1px solid #334155; color: #94a3b8; }
+    .dark-theme tr:nth-child(even) td { background-color: #1e293b; }
+    .dark-theme tr:nth-child(odd) td { background-color: #111827; }
+    .dark-theme tr:hover td { background-color: #334155; color: #f8fafc; }
+    .dark-theme td b { color: #f1f5f9; }
+    .dark-theme .word-btn { background-color: #1e293b; border: 1px solid #475569; color: #f8fafc; }
+    .dark-theme .word-btn:hover { background-color: #334155; }
+
+    #main-container { padding: 24px; display: flex; flex-direction: column; position: relative; }
+    .layer-title { font-size: 20px; font-weight: 600; margin-bottom: 2px; padding-right: 180px; }
+    h3 { margin: 0 0 16px 0; font-size: 20px; font-weight: 600; padding-bottom: 8px; }
+    .section-title { margin: 20px 0 8px 0; font-size: 13px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; }
+    .table-card { border-radius: 8px; overflow: hidden; transition: background 0.2s, border 0.2s; }
+    table { width: 100%; border-collapse: collapse; text-align: left; }
+    th, td { padding: 14px 18px; font-size: 14px; line-height: 1.5; word-break: break-all; }
+    th { font-weight: 600; text-transform: uppercase; font-size: 12px; letter-spacing: 0.05em; width: 35%; }
+    td b { font-weight: 500; }
+    .controls-wrapper { position: absolute; top: 22px; right: 24px; display: flex; align-items: center; gap: 16px; }
+    .word-btn { padding: 4px 10px; font-size: 12px; font-weight: 500; border-radius: 4px; cursor: pointer; display: flex; align-items: center; gap: 6px; transition: background-color 0.2s; }
+    .theme-switch-wrapper { display: flex; align-items: center; gap: 8px; font-size: 12px; font-weight: 500; }
+    .theme-switch { display: inline-block; height: 20px; position: relative; width: 36px; }
+    .theme-switch input { display:none; }
+    .slider { background-color: #cbd5e1; bottom: 0; cursor: pointer; left: 0; position: absolute; right: 0; top: 0; transition: .2s; border-radius: 20px; }
+    .slider:before { background-color: white; bottom: 3px; content: ""; height: 14px; left: 3px; position: absolute; transition: .2s; width: 14px; border-radius: 50%; }
+    input:checked + .slider { background-color: #38bdf8; }
+    input:checked + .slider:before { transform: translateX(16px); }
+</style>
+<!-- Include the internal Qt WebChannel Script framework to link JS with Python Backend -->
+<script src="qrc:///qtwebchannel/qwebchannel.js"></script>
+</head>
+<body class="dark-theme">
+    <div id="main-container">
+        <div class="layer-title">__QPANSOPY_TITLE__</div>
+        <h3>Feature Parameters</h3>
+
+        <div class="controls-wrapper">
+            <button class="word-btn" onclick="triggerNativeCopy()">Copy to Word</button>
+            <div class="theme-switch-wrapper">
+                <span id="theme-label">Dark Mode</span>
+                <label class="theme-switch" for="checkbox">
+                    <input type="checkbox" id="checkbox" checked />
+                    <div class="slider"></div>
+                </label>
+            </div>
+        </div>
+
+__QPANSOPY_SECTIONS__
+    </div>
+
+    <script>
+        let backendBridge;
+        // Establish runtime links with the PyQt backend bridge container channels
+        new QWebChannel(qt.webChannelTransport, function (channel) {
+            backendBridge = channel.objects.pyBridge;
+        });
+
+        const toggleSwitch = document.querySelector('#checkbox');
+        const themeLabel = document.querySelector('#theme-label');
+
+        toggleSwitch.addEventListener('change', (e) => {
+            if (e.target.checked) {
+                document.body.className = 'dark-theme';
+                themeLabel.textContent = 'Dark Mode';
+            } else {
+                document.body.className = 'light-theme';
+                themeLabel.textContent = 'Light Mode';
+            }
+        }, false);
+
+        function triggerNativeCopy() {
+            if (backendBridge) {
+                backendBridge.copyToClipboard();
+                const btn = document.querySelector('.word-btn');
+                const originalText = btn.innerHTML;
+                btn.innerHTML = '✔ Copied!';
+                setTimeout(() => { btn.innerHTML = originalText; }, 1500);
+            }
+        }
+    </script>
+</body>
+</html>
+"""
 
 
-class ParametersInspectorDialog(QDialog):
-    """Read-only popup rendering a feature's stored parameters as an HTML table."""
+def _format_value(value):
+    return json.dumps(value) if isinstance(value, (dict, list)) else str(value)
 
-    def __init__(self, title, html_table, text_table, parent=None):
+
+def _build_rows_html(flat_params):
+    rows = []
+    for key, value in flat_params.items():
+        rows.append(
+            f"<tr><td><b>{html.escape(str(key))}</b></td>"
+            f"<td>{html.escape(_format_value(value))}</td></tr>"
+        )
+    return "".join(rows)
+
+
+def _build_section_html(section_title, flat_params, show_heading):
+    heading = f'<h4 class="section-title">{html.escape(section_title)}</h4>' if show_heading else ''
+    rows = _build_rows_html(flat_params)
+    return (
+        f'{heading}<div class="table-card"><table>'
+        f'<tr><th>Parameter</th><th>Value</th></tr>{rows}</table></div>'
+    )
+
+
+def _build_page_html(title, sections):
+    """
+    sections: list of (section_title, flat_params_dict) pairs. A single
+    section renders exactly like the reference sample (no sub-heading);
+    multiple sections (e.g. Basic ILS/OAS ILS aggregating every matching
+    layer in the project) each get their own labelled table-card.
+    """
+    show_heading = len(sections) > 1
+    sections_html = "".join(
+        _build_section_html(section_title, flat_params, show_heading)
+        for section_title, flat_params in sections
+    )
+    page = _PAGE_TEMPLATE.replace("__QPANSOPY_TITLE__", html.escape(title))
+    page = page.replace("__QPANSOPY_SECTIONS__", sections_html)
+    return page
+
+
+class ClipboardBridge(QObject):
+    """JS-callable bridge (via QWebChannel) that copies a clean, Word-pasteable
+    HTML table to the native clipboard -- QWebEngineView content runs in a
+    separate process/sandbox, so JS can't touch the OS clipboard directly."""
+
+    def __init__(self, sections):
+        super().__init__()
+        self._sections = sections
+
+    @pyqtSlot()
+    def copyToClipboard(self):
+        multi = len(self._sections) > 1
+        html_parts = []
+        text_parts = []
+        for section_title, flat_params in self._sections:
+            html_parts.append(format_parameters_table(section_title, flat_params, as_html=True))
+            text_parts.append(format_parameters_table(section_title, flat_params, as_html=False))
+        mime = QMimeData()
+        mime.setHtml("<div>" + "<br>".join(html_parts) + "</div>" if multi else html_parts[0])
+        mime.setText("\n\n".join(text_parts))
+        QApplication.clipboard().setMimeData(mime)
+
+
+def show_web_popup(title, sections):
+    """
+    Show a Parameters Inspector popup for one or more (section_title,
+    flat_params_dict) pairs. Non-modal; kept alive in _open_views until
+    the window is closed. Uses QWebEngineView when available (matching
+    issue #193's requested look: dark-mode-by-default with a live toggle),
+    falling back to a QTextBrowser popup otherwise.
+    """
+    if _WEBENGINE_AVAILABLE:
+        return _show_webengine_popup(title, sections)
+    return _show_textbrowser_popup(title, sections)
+
+
+def _show_webengine_popup(title, sections):
+    page_html = _build_page_html(title, sections)
+
+    view = QWebEngineView()
+    bridge = ClipboardBridge(sections)
+    channel = QWebChannel(view.page())
+    view.page().setWebChannel(channel)
+    channel.registerObject("pyBridge", bridge)
+
+    view.setHtml(page_html)
+    view.setWindowTitle(title)
+
+    screen = view.screen().geometry()
+    max_width = int(screen.width() / 3)
+    max_height = int(screen.height() * 0.75)
+    view.resize(max_width, max_height)
+
+    def _fit_to_content(_ok=None):
+        view.page().runJavaScript(
+            "document.getElementById('main-container').offsetHeight",
+            lambda rendered_height: view.resize(max_width, min(int(rendered_height) + 12, max_height))
+        )
+
+    view.loadFinished.connect(_fit_to_content)
+
+    key = id(view)
+    _open_views[key] = (view, bridge, channel)
+    view.destroyed.connect(lambda: _open_views.pop(key, None))
+
+    view.show()
+    return view
+
+
+# ---------------------------------------------------------------------------
+# QTextBrowser fallback (no QtWebEngine available): a static render of the
+# same data, dark-by-default. QTextBrowser can't run JavaScript, so the
+# light/dark toggle and "Copy to Word" are plain QPushButtons instead of the
+# JS/QWebChannel-driven controls in the WebEngine version -- the toggle just
+# re-renders the HTML with a different colour palette and calls setHtml()
+# again; "Copy to Word" calls ClipboardBridge directly.
+# ---------------------------------------------------------------------------
+
+_FALLBACK_PALETTES = {
+    'dark': {
+        'bg': '#0f172a', 'title_fg': '#f8fafc', 'h3_fg': '#f8fafc', 'h3_border': '#1e293b',
+        'section_fg': '#94a3b8', 'card_border': '#334155',
+        'th_bg': '#020617', 'th_fg': '#38bdf8',
+        'row_even': '#1e293b', 'row_odd': '#111827', 'td_border': '#334155',
+        'key_fg': '#f1f5f9', 'value_fg': '#94a3b8',
+    },
+    'light': {
+        'bg': '#f4f6f9', 'title_fg': '#1e293b', 'h3_fg': '#1e293b', 'h3_border': '#e2e8f0',
+        'section_fg': '#475569', 'card_border': '#e2e8f0',
+        'th_bg': '#0f172a', 'th_fg': '#ffffff',
+        'row_even': '#ffffff', 'row_odd': '#f8fafc', 'td_border': '#f1f5f9',
+        'key_fg': '#1e293b', 'value_fg': '#475569',
+    },
+}
+
+
+def _build_fallback_rows_html(flat_params, palette):
+    rows = []
+    for idx, (key, value) in enumerate(flat_params.items()):
+        bg = palette['row_even'] if idx % 2 == 0 else palette['row_odd']
+        rows.append(
+            f'<tr>'
+            f'<td style="background-color:{bg}; color:{palette["key_fg"]}; padding:10px; '
+            f'border-bottom:1px solid {palette["td_border"]};"><b>{html.escape(str(key))}</b></td>'
+            f'<td style="background-color:{bg}; color:{palette["value_fg"]}; padding:10px; '
+            f'border-bottom:1px solid {palette["td_border"]};">{html.escape(_format_value(value))}</td></tr>'
+        )
+    return "".join(rows)
+
+
+def _build_fallback_section_html(section_title, flat_params, show_heading, palette):
+    heading = (
+        f'<h4 style="color:{palette["section_fg"]}; text-transform:uppercase; font-size:12px; '
+        f'letter-spacing:0.05em; margin:20px 0 8px 0;">{html.escape(section_title)}</h4>'
+    ) if show_heading else ''
+    rows = _build_fallback_rows_html(flat_params, palette)
+    header_style = (
+        f'background-color:{palette["th_bg"]}; color:{palette["th_fg"]}; padding:12px; text-align:left; '
+        'text-transform:uppercase; font-size:12px;'
+    )
+    return (
+        f'{heading}<table style="width:100%; border-collapse:collapse; '
+        f'border:1px solid {palette["card_border"]}; border-radius:8px;">'
+        f'<tr><th style="{header_style}">Parameter</th><th style="{header_style}">Value</th></tr>'
+        f'{rows}</table>'
+    )
+
+
+def _build_fallback_page_html(title, sections, theme='dark'):
+    palette = _FALLBACK_PALETTES[theme]
+    show_heading = len(sections) > 1
+    sections_html = "".join(
+        _build_fallback_section_html(section_title, flat_params, show_heading, palette)
+        for section_title, flat_params in sections
+    )
+    return (
+        f'<body style="background-color:{palette["bg"]}; color:{palette["value_fg"]}; '
+        'font-family:\'Segoe UI\',Arial,sans-serif; padding:4px;">'
+        f'<h3 style="color:{palette["h3_fg"]}; border-bottom:2px solid {palette["h3_border"]}; '
+        'padding-bottom:8px; margin-top:0;">Feature Parameters</h3>'
+        f'{sections_html}</body>'
+    )
+
+
+class _FallbackParametersDialog(QDialog):
+    """Static QTextBrowser popup used when QtWebEngine isn't installed.
+    Ships its own native (non-JS) light/dark toggle button."""
+
+    def __init__(self, title, sections, parent=None):
         super().__init__(parent)
         self.setWindowTitle(title)
-        self.setMinimumSize(480, 420)
-        self.setStyleSheet(load_base_qss())
-        self._html_table = html_table
-        self._text_table = text_table
-        self._setup_ui()
+        self.setMinimumSize(520, 360)
+        self._sections = sections
+        self._title = title
+        self._theme = 'dark'
 
-    def _setup_ui(self):
         layout = QVBoxLayout(self)
 
-        browser = QTextBrowser(self)
-        # The dialog's dark QSS (load_base_qss()) styles bare QTextEdit as a
-        # dark log panel (near-black background, light-gray text) -- correct
-        # for the log widgets it was written for, but it also matches
-        # QTextBrowser (a QTextEdit subclass), muddying the table's own
-        # white/light-gray cell backgrounds and leaving text low-contrast.
-        # Override locally so the rendered table stays crisp and readable.
-        browser.setStyleSheet(
-            "QTextBrowser { background-color: #ffffff; color: #202020; border: 1px solid #444; }"
-        )
-        browser.setHtml(self._html_table)
-        layout.addWidget(browser)
+        header_row = QHBoxLayout()
+        title_label = QLabel(title)
+        title_label.setStyleSheet("font-size: 16px; font-weight: 600; color: #f8fafc;")
+        header_row.addWidget(title_label)
+        header_row.addStretch()
+        copy_btn = QPushButton("Copy to Word")
+        copy_btn.clicked.connect(self._copy_to_word)
+        header_row.addWidget(copy_btn)
+        self._theme_btn = QPushButton()
+        self._theme_btn.clicked.connect(self._toggle_theme)
+        header_row.addWidget(self._theme_btn)
+        layout.addLayout(header_row)
+
+        self._browser = QTextBrowser(self)
+        layout.addWidget(self._browser)
 
         button_row = QHBoxLayout()
-        copy_btn = QPushButton("Copy to Word")
-        copy_btn.clicked.connect(self.copy_to_word)
-        button_row.addWidget(copy_btn)
         button_row.addStretch()
         close_btn = QPushButton("Close")
         close_btn.clicked.connect(self.close)
         button_row.addWidget(close_btn)
         layout.addLayout(button_row)
 
-    def copy_to_word(self):
-        mime = QMimeData()
-        mime.setHtml(self._html_table)
-        mime.setText(self._text_table)
-        QApplication.clipboard().setMimeData(mime)
+        self._render()
+
+    def _render(self):
+        palette = _FALLBACK_PALETTES[self._theme]
+        self._theme_btn.setText("🌙 Dark Mode" if self._theme == 'dark' else "☀ Light Mode")
+        self._browser.setStyleSheet(
+            f"QTextBrowser {{ background-color: {palette['bg']}; border: 1px solid {palette['card_border']}; }}"
+        )
+        self._browser.setHtml(_build_fallback_page_html(self._title, self._sections, self._theme))
+
+    def _toggle_theme(self):
+        self._theme = 'light' if self._theme == 'dark' else 'dark'
+        self._render()
+
+    def _copy_to_word(self):
+        ClipboardBridge(self._sections).copyToClipboard()
+
+
+def _show_textbrowser_popup(title, sections):
+    dialog = _FallbackParametersDialog(title, sections)
+    key = id(dialog)
+    _open_views[key] = dialog
+    dialog.finished.connect(lambda _result: _open_views.pop(key, None))
+    dialog.show()
+    return dialog
 
 
 def resolve_inspector_title(parameters_dict, fallback):
     """
-    Pick a readable dialog title: the stored 'calculation_type' if present,
+    Pick a readable popup title: the stored 'calculation_type' if present,
     else *fallback* (e.g. the layer name).
     """
     calculation_type = parameters_dict.get('calculation_type') if isinstance(parameters_dict, dict) else None
@@ -108,7 +446,7 @@ def show_parameters_inspector(layer_id, feature_id):
     """
     Entry point for the QGIS layer action registered by
     register_parameters_action(). Resolves the feature's stored 'parameters'
-    JSON and shows it in a ParametersInspectorDialog.
+    JSON and shows it in a Parameters Inspector popup.
     """
     layer = QgsProject.instance().mapLayer(layer_id)
     if layer is None:
@@ -132,24 +470,22 @@ def show_parameters_inspector(layer_id, feature_id):
         return
 
     title = resolve_inspector_title(parsed, layer.name())
-    html_table = format_parameters_table(title, parsed, as_html=True)
-    text_table = format_parameters_table(title, parsed, as_html=False)
-
-    dialog = ParametersInspectorDialog(title, html_table, text_table)
-    _open_dialogs.append(dialog)
-    dialog.finished.connect(lambda _result: _open_dialogs.remove(dialog) if dialog in _open_dialogs else None)
-    dialog.show()
+    show_web_popup(title, [(layer.name(), parsed)])
 
 
 def register_parameters_action(layer):
     """
-    Register a 'Show Parameters' QGIS layer action on *layer*, so any
-    feature with a 'parameters' attribute can be inspected as a rendered
-    HTML table from the Attribute Table / Identify results (issue #193).
+    Register the 'view parameters as HTML Table' QGIS layer action on
+    *layer*, so any feature with a 'parameters' attribute can be inspected
+    as a rendered HTML table from the Attribute Table / canvas Identify
+    results (issue #193). Action scopes are set explicitly to Feature and
+    Canvas -- without this the action is registered but invisible until a
+    user manually enables those scopes in Layer Properties > Actions.
     """
     action_code = (
         "from Q_Pansopy.parameters_inspector_dialog import show_parameters_inspector\n"
         "show_parameters_inspector('[% @layer_id %]', [% $id %])"
     )
-    action = QgsAction(_generic_python_action_type(), "Show Parameters (QPANSOPY)", action_code)
+    action = QgsAction(_generic_python_action_type(), "view parameters as HTML Table", action_code)
+    action.setActionScopes({'Feature', 'Canvas'})
     layer.actions().addAction(action)

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,3 +28,6 @@ per-file-ignores =
     Q_Pansopy/dockwidgets/ils/qpansopy_oas_ils_dockwidget.py: E111,E114,E501
     # utils.py: late import of simplejson/csv at module bottom avoids circular dependency at load time.
     Q_Pansopy/utils.py: E402
+    # parameters_inspector_dialog.py: embedded HTML/CSS/JS template kept as single-line CSS
+    # rules (matching the reference sample from issue #193) for easy visual scanning/diffing.
+    Q_Pansopy/parameters_inspector_dialog.py: E501

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,6 +68,8 @@ def _install_qgis_stubs():
         'Double': 6, 'QString': 10, 'Int': 2,
     })
     qtcore.pyqtSignal = lambda *a, **kw: None
+    qtcore.pyqtSlot = lambda *a, **kw: (lambda fn: fn)
+    qtcore.QObject = _Dummy
     qtcore.QMimeData = _Dummy
     qtgui.QColor = _Dummy
 
@@ -77,11 +79,20 @@ def _install_qgis_stubs():
     PyQt.uic = uic
     sys.modules['qgis.PyQt.uic'] = uic
 
+    # QtWebEngineWidgets / QtWebChannel stubs — needed by parameters_inspector_dialog.py
+    webengine = types.ModuleType('qgis.PyQt.QtWebEngineWidgets')
+    webengine.QWebEngineView = _Dummy
+    sys.modules['qgis.PyQt.QtWebEngineWidgets'] = webengine
+
+    webchannel = types.ModuleType('qgis.PyQt.QtWebChannel')
+    webchannel.QWebChannel = _Dummy
+    sys.modules['qgis.PyQt.QtWebChannel'] = webchannel
+
     for widget_name in [
         'QFileDialog', 'QDialog', 'QFormLayout', 'QLineEdit', 'QComboBox',
         'QDialogButtonBox', 'QMessageBox', 'QWidget', 'QApplication',
         'QDockWidget', 'QPushButton', 'QTextEdit', 'QGroupBox', 'QVBoxLayout',
-        'QHBoxLayout', 'QTextBrowser',
+        'QHBoxLayout', 'QTextBrowser', 'QLabel',
     ]:
         setattr(qtwidgets, widget_name, _Dummy)
 
@@ -132,7 +143,8 @@ def _install_qgis_stubs():
     finally:
         names_to_clean = [
             'PyQt5.QtWidgets', 'PyQt5.QtGui', 'PyQt5.QtCore', 'PyQt5',
-            'qgis.PyQt.uic', 'qgis.PyQt.QtWidgets', 'qgis.PyQt.QtCore',
+            'qgis.PyQt.uic', 'qgis.PyQt.QtWebEngineWidgets', 'qgis.PyQt.QtWebChannel',
+            'qgis.PyQt.QtWidgets', 'qgis.PyQt.QtCore',
             'qgis.PyQt.QtGui', 'qgis.PyQt', 'qgis.gui', 'qgis.core', 'qgis.utils', 'qgis',
         ]
         for name in names_to_clean:

--- a/tests/unit/test_parameters_inspector_dialog.py
+++ b/tests/unit/test_parameters_inspector_dialog.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 """
-Tests for issue #193: registering the 'Show Parameters' QGIS layer action and
-resolving a readable dialog title from the stored 'parameters' JSON.
+Tests for issue #193 (and its follow-up): registering the 'view parameters
+as HTML Table' QGIS layer action with the correct name/scopes, resolving a
+readable popup title, building the multi-section HTML, and the clipboard
+bridge used by the popup's 'Copy to Word' button.
 """
 import importlib
 
@@ -52,6 +54,19 @@ class _FakeLayer:
         return self._actions
 
 
+class _FakeQgsAction:
+    GenericPython = 'generic-python'
+
+    def __init__(self, action_type, name, action_code):
+        self.action_type = action_type
+        self.name = name
+        self.action_code = action_code
+        self.action_scopes = None
+
+    def setActionScopes(self, scopes):
+        self.action_scopes = scopes
+
+
 def test_register_parameters_action_uses_safe_substitution_tokens(monkeypatch):
     """
     Regression guard: the action code must resolve the feature via
@@ -60,26 +75,193 @@ def test_register_parameters_action_uses_safe_substitution_tokens(monkeypatch):
     that break the generated Python literal.
     """
     mod = _mod()
-
-    captured = {}
-
-    class _FakeQgsAction:
-        GenericPython = 'generic-python'
-
-        def __init__(self, action_type, name, action_code):
-            captured['action_type'] = action_type
-            captured['name'] = name
-            captured['action_code'] = action_code
-
     monkeypatch.setattr(mod, 'QgsAction', _FakeQgsAction)
 
     layer = _FakeLayer()
     mod.register_parameters_action(layer)
 
     assert len(layer._actions.added) == 1
-    code = captured['action_code']
+    action = layer._actions.added[0]
+    code = action.action_code
     assert 'show_parameters_inspector' in code
     assert '@layer_id' in code
     assert '$id' in code
     # Never interpolate the raw parameters JSON directly into the action code.
     assert '"parameters"' not in code
+
+
+def test_register_parameters_action_name_and_scopes(monkeypatch):
+    """
+    Regression guard for issue #193's follow-up: the action must be named
+    exactly 'view parameters as HTML Table', and must explicitly set the
+    Feature/Canvas action scopes -- without this the action is registered
+    but invisible until a user manually enables those scopes.
+    """
+    mod = _mod()
+    monkeypatch.setattr(mod, 'QgsAction', _FakeQgsAction)
+
+    layer = _FakeLayer()
+    mod.register_parameters_action(layer)
+
+    action = layer._actions.added[0]
+    assert action.name == 'view parameters as HTML Table'
+    assert action.action_scopes == {'Feature', 'Canvas'}
+
+
+# ---------------------------------------------------------------------------
+# HTML builder (_build_page_html / _build_rows_html / _build_section_html)
+# ---------------------------------------------------------------------------
+
+def test_build_page_html_single_section_has_no_subheading():
+    mod = _mod()
+    page = mod._build_page_html("Wind Spiral — Feature Parameters", [("Wind Spiral", {'IAS': 205})])
+
+    assert "Wind Spiral — Feature Parameters" in page
+    assert 'class="section-title"' not in page
+    assert "<td><b>IAS</b></td><td>205</td>" in page
+    assert 'class="dark-theme"' in page  # dark mode by default
+
+
+def test_build_page_html_multiple_sections_get_subheadings():
+    mod = _mod()
+    page = mod._build_page_html("Basic ILS — Feature Parameters", [
+        ("Layer A", {'thr_elev': 100}),
+        ("Layer B", {'thr_elev': 200}),
+    ])
+
+    assert page.count('class="section-title"') == 2
+    assert "Layer A" in page
+    assert "Layer B" in page
+
+
+def test_build_page_html_escapes_values():
+    mod = _mod()
+    page = mod._build_page_html("Title", [("Section", {'note': '<script>alert(1)</script>'})])
+
+    assert '<script>alert(1)</script>' not in page
+    assert '&lt;script&gt;' in page
+
+
+# ---------------------------------------------------------------------------
+# ClipboardBridge
+# ---------------------------------------------------------------------------
+
+def test_clipboard_bridge_copies_word_table(monkeypatch):
+    mod = _mod()
+
+    captured = {}
+
+    class _FakeMimeData:
+        def setHtml(self, value):
+            captured['html'] = value
+
+        def setText(self, value):
+            captured['text'] = value
+
+    class _FakeClipboard:
+        def setMimeData(self, mime):
+            captured['mime'] = mime
+
+    class _FakeQApplication:
+        @staticmethod
+        def clipboard():
+            return _FakeClipboard()
+
+    monkeypatch.setattr(mod, 'QMimeData', _FakeMimeData)
+    monkeypatch.setattr(mod, 'QApplication', _FakeQApplication)
+
+    bridge = mod.ClipboardBridge([("Wind Spiral", {'IAS': 205})])
+    bridge.copyToClipboard()
+
+    assert '205' in captured['html']
+    assert '205' in captured['text']
+    assert captured['mime'] is not None
+
+
+# ---------------------------------------------------------------------------
+# QTextBrowser fallback (QtWebEngine unavailable -- issue #193 follow-up)
+# ---------------------------------------------------------------------------
+
+def test_build_fallback_page_html_single_section_has_no_subheading():
+    mod = _mod()
+    page = mod._build_fallback_page_html("Wind Spiral — Feature Parameters", [("Wind Spiral", {'IAS': 205})])
+
+    # The title itself is shown via a native QLabel in the dialog header, not
+    # embedded in the browser HTML -- only "Feature Parameters" + the table are.
+    assert "Feature Parameters" in page
+    assert "<h4" not in page
+    assert "205" in page
+    assert "#0f172a" in page  # dark background by default
+
+
+def test_build_fallback_page_html_light_theme_uses_light_palette():
+    mod = _mod()
+    dark_page = mod._build_fallback_page_html("Title", [("Section", {'a': 1})], theme='dark')
+    light_page = mod._build_fallback_page_html("Title", [("Section", {'a': 1})], theme='light')
+
+    assert "#f4f6f9" in light_page  # light body background
+    assert "#f4f6f9" not in dark_page
+    assert "#0f172a" in dark_page  # dark body background
+    assert dark_page != light_page
+
+
+def test_fallback_dialog_toggle_theme_flips_state():
+    """Regression guard: the fallback popup must offer a working light/dark
+    toggle even without QtWebEngine/JS -- a plain button flips this state
+    and re-renders the static HTML."""
+    mod = _mod()
+    dialog = mod._FallbackParametersDialog("Title", [("Section", {'a': 1})])
+
+    assert dialog._theme == 'dark'
+    dialog._toggle_theme()
+    assert dialog._theme == 'light'
+    dialog._toggle_theme()
+    assert dialog._theme == 'dark'
+
+
+def test_build_fallback_page_html_multiple_sections_get_subheadings():
+    mod = _mod()
+    page = mod._build_fallback_page_html("Basic ILS — Feature Parameters", [
+        ("Layer A", {'thr_elev': 100}),
+        ("Layer B", {'thr_elev': 200}),
+    ])
+
+    assert page.count("<h4") == 2
+    assert "Layer A" in page
+    assert "Layer B" in page
+
+
+def test_build_fallback_page_html_escapes_values():
+    mod = _mod()
+    page = mod._build_fallback_page_html("Title", [("Section", {'note': '<script>alert(1)</script>'})])
+
+    assert '<script>alert(1)</script>' not in page
+    assert '&lt;script&gt;' in page
+
+
+def test_show_web_popup_falls_back_when_webengine_unavailable(monkeypatch):
+    """
+    Regression guard: on systems missing the optional QtWebEngine Qt
+    bindings (e.g. python-pyqt6-webengine not installed), show_web_popup()
+    must degrade to the QTextBrowser popup instead of raising.
+    """
+    mod = _mod()
+    monkeypatch.setattr(mod, '_WEBENGINE_AVAILABLE', False)
+
+    result = mod.show_web_popup("Wind Spiral — Feature Parameters", [("Wind Spiral", {'IAS': 205})])
+
+    assert isinstance(result, mod._FallbackParametersDialog)
+
+
+def test_show_web_popup_uses_webengine_when_available(monkeypatch):
+    mod = _mod()
+    monkeypatch.setattr(mod, '_WEBENGINE_AVAILABLE', True)
+
+    calls = []
+    monkeypatch.setattr(mod, '_show_webengine_popup', lambda title, sections: calls.append((title, sections)))
+    monkeypatch.setattr(mod, '_show_textbrowser_popup', lambda title, sections: (_ for _ in ()).throw(
+        AssertionError('should not use the fallback when WebEngine is available')))
+
+    mod.show_web_popup("Title", [("Section", {'a': 1})])
+
+    assert calls == [("Title", [("Section", {'a': 1})])]


### PR DESCRIPTION
# PR — Parameters Inspector follow-up (Issue #193, reopened)

## Summary

- Fixed the "view parameters as HTML Table" layer action not appearing anywhere until the
  Feature/Canvas action scopes were manually enabled — `register_parameters_action()` now sets
  them explicitly.
- Renamed the action to the exact requested name.
- Replaced the `QTextBrowser`-based popup with a `QWebEngineView` popup matching the reporter's
  reference sample: dark-mode-by-default, a working light/dark toggle switch, hover states, Segoe
  UI styling, and a `QWebChannel`-bridged "Copy to Word" button. Both the layer action and every
  dockwidget's "Show Table" button now open this same popup.
- Added a graceful fallback: `QtWebEngineWidgets`/`QtWebChannel` are optional, heavy Qt add-ons
  (e.g. `python-pyqt6-webengine` on Arch/CachyOS) not guaranteed to be installed alongside QGIS —
  surfaced during testing as a `ModuleNotFoundError` crash on "Show Table". If unavailable, the
  popup now degrades to a `QTextBrowser` view instead of crashing — still dark-by-default, and
  still with a **working light/dark toggle**, implemented natively (a `QPushButton` that re-renders
  the static HTML with a different colour palette) since `QTextBrowser` can't run the JS-driven
  toggle the WebEngine version uses.

## Root cause

PR #203's `QgsAction` never called `setActionScopes()` — QGIS actions are invisible everywhere
until their scopes are set, so the action existed but never showed up in the Attribute Table or
canvas Identify results without a manual Layer Properties step. Separately, `QTextBrowser` can't
run JavaScript, so it couldn't support a real theme toggle or a JS-triggered clipboard bridge —
both explicitly requested with a working reference implementation.

## Implementation notes

- The reporter's sample interpolates `[% "parameters" %]` (the raw JSON) directly into the
  generated action text. We kept the original implementation's safer approach instead: the action
  text only substitutes `[% @layer_id %]`/`[% $id %]` (plain, quote-free strings/ints), and the
  feature/JSON is resolved in Python — same visual/functional result, without ever needing to
  interpolate arbitrary stored JSON into generated Python source.
- Extracted the reporter's HTML/CSS/JS into a shared template supporting **multiple sections**
  (`[(section_title, flat_params_dict), ...]`), so `basic_ils`/`oas_ils`'s dockwidget buttons keep
  their existing "aggregate every matching layer" behavior (one table-card per layer) instead of
  losing it; the common single-section case renders identically to the reference sample.
- `ClipboardBridge.copyToClipboard()` still builds the clipboard content via
  `Q_Pansopy/utils.py::format_parameters_table()` — the same proven Word-paste table used
  elsewhere in the plugin, intentionally different (light, Word-styled) from the dark on-screen
  view, matching the reporter's own sample's separation of concerns.

## Files Modified

| File | Change |
|---|---|
| `Q_Pansopy/parameters_inspector_dialog.py` | Rewritten: `QWebEngineView` popup, multi-section support, action name/scopes fix, `QTextBrowser` fallback when QtWebEngine isn't installed |
| 6 dockwidgets (`wind_spiral`, `ils`, `oas_ils`, `vss`, `holding`, `sid_initial`) | `show_parameters_table()` now calls `show_web_popup(title, sections)` |
| `tests/conftest.py` | Added `QObject`/`pyqtSlot`, `QtWebEngineWidgets`/`QtWebChannel` stubs |
| `tests/unit/test_parameters_inspector_dialog.py` | Updated/expanded tests |
| `setup.cfg` | Per-file E501 ignore for the new module's embedded CSS template |
| `Q_Pansopy/metadata.txt` | Changelog bullet |
| `docs/plan-193-followup.md` | Implementation plan |

## Test plan

- [x] `pytest tests/ -q` — no regressions, updated/new tests pass.
- [x] `flake8`/`bandit` on all touched files — no new findings.
- [ ] In QGIS: open the Attribute Table for any of the 5 parameter-bearing layers, confirm "view
  parameters as HTML Table" appears in the Actions column with **no manual scope configuration**.
- [ ] Popup opens dark-mode by default; toggle switches to light mode and back correctly.
- [ ] "Copy to Word" pastes a clean table into Word.
- [ ] Each of the 6 dockwidgets' "Show Table" button opens the same style of popup; Basic
  ILS/OAS ILS show one card per matching layer.
- [ ] With `python-pyqt6-webengine` (or the Qt5 equivalent) uninstalled, "Show Table" degrades to
  the dark `QTextBrowser` popup instead of crashing; its "Dark Mode"/"Light Mode" button toggles
  correctly, and "Copy to Word" still works.

## Related

Follow-up to #193 / PR #203.
