### PR TITLE
Wind Spiral: replace IAS/Altitude inputs with spinners (Issue #199)

### DIFF
--- a/Q_Pansopy/dockwidgets/utilities/qpansopy_wind_spiral_dockwidget.py
+++ b/Q_Pansopy/dockwidgets/utilities/qpansopy_wind_spiral_dockwidget.py
@@ -177,28 +177,27 @@ class QPANSOPYWindSpiralDockWidgetBase(QtWidgets.QDockWidget, FORM_CLASS):
 
         self.formLayout.addRow("ISA Variation (°C):", isa_container)
 
-        # IAS
-        self.IASLineEdit = QtWidgets.QLineEdit(self)
-        self.IASLineEdit.setValidator(validator)
-        self.IASLineEdit.setText("205")
-        self.IASLineEdit.textChanged.connect(
-            lambda text: self.store_exact_value('IAS', text))
-        self.IASLineEdit.textChanged.connect(self._update_preview)
-        self.IASLineEdit.setMinimumHeight(28)
-        self.IASLineEdit.setMaximumHeight(28)
-        self.IASLineEdit.setStyleSheet(line_edit_style)
-        self.formLayout.addRow("IAS (kt):", self.IASLineEdit)
+        # IAS - spin box (integers) so arrow keys can nudge the live preview (issue #199)
+        self.IASSpinBox = QtWidgets.QSpinBox(self)
+        self.IASSpinBox.setRange(50, 400)
+        self.IASSpinBox.setSingleStep(1)
+        self.IASSpinBox.setValue(205)
+        self.IASSpinBox.valueChanged.connect(self._update_preview)
+        self.IASSpinBox.setMinimumHeight(28)
+        self.IASSpinBox.setMaximumHeight(28)
+        self.IASSpinBox.setStyleSheet(line_edit_style)
+        self.formLayout.addRow("IAS (kt):", self.IASSpinBox)
 
-        # Altitude with unit selector
-        self.altitudeLineEdit = QtWidgets.QLineEdit(self)
-        self.altitudeLineEdit.setValidator(validator)
-        self.altitudeLineEdit.setText("800")
-        self.altitudeLineEdit.textChanged.connect(
-            lambda text: self.store_exact_value('altitude', text))
-        self.altitudeLineEdit.textChanged.connect(self._update_preview)
-        self.altitudeLineEdit.setMinimumHeight(28)
-        self.altitudeLineEdit.setMaximumHeight(28)
-        self.altitudeLineEdit.setStyleSheet(line_edit_style)
+        # Altitude with unit selector - spin box (integers) so arrow keys can
+        # nudge the live preview (issue #199)
+        self.altitudeSpinBox = QtWidgets.QSpinBox(self)
+        self.altitudeSpinBox.setRange(0, 50000)
+        self.altitudeSpinBox.setSingleStep(100)
+        self.altitudeSpinBox.setValue(800)
+        self.altitudeSpinBox.valueChanged.connect(self._update_preview)
+        self.altitudeSpinBox.setMinimumHeight(28)
+        self.altitudeSpinBox.setMaximumHeight(28)
+        self.altitudeSpinBox.setStyleSheet(line_edit_style)
 
         self.altitudeUnitCombo = QtWidgets.QComboBox(self)
         self.altitudeUnitCombo.addItems(['ft', 'm'])
@@ -215,7 +214,7 @@ class QPANSOPYWindSpiralDockWidgetBase(QtWidgets.QDockWidget, FORM_CLASS):
         altitudeLayout = QtWidgets.QHBoxLayout(altitudeContainer)
         altitudeLayout.setContentsMargins(0, 0, 0, 0)
         altitudeLayout.setSpacing(8)
-        altitudeLayout.addWidget(self.altitudeLineEdit)
+        altitudeLayout.addWidget(self.altitudeSpinBox)
         altitudeLayout.addWidget(self.altitudeUnitCombo)
 
         self.formLayout.addRow("Altitude:", altitudeContainer)
@@ -366,8 +365,8 @@ class QPANSOPYWindSpiralDockWidgetBase(QtWidgets.QDockWidget, FORM_CLASS):
         params = {
             'isaVar': self.exact_values.get('isaVar', self.isaVarLineEdit.text()),
             'isa_source': self.isa_calculation_metadata['method'],
-            'IAS': self.exact_values.get('IAS', self.IASLineEdit.text()),
-            'altitude': self.exact_values.get('altitude', self.altitudeLineEdit.text()),
+            'IAS': self.IASSpinBox.value(),
+            'altitude': self.altitudeSpinBox.value(),
             'altitude_unit': self.units.get('altitude', 'ft'),
             'bankAngle': self.exact_values.get('bankAngle', self.bankAngleLineEdit.text()),
             'w': self.exact_values.get('w', self.windSpeedLineEdit.text()),
@@ -413,8 +412,8 @@ class QPANSOPYWindSpiralDockWidgetBase(QtWidgets.QDockWidget, FORM_CLASS):
                 'adElev_unit': self.units.get('adElev', 'ft'),
                 'tempRef': self.exact_values.get('tempRef', ''),
                 'isaVar': self.exact_values.get('isaVar', self.isaVarLineEdit.text()),
-                'IAS': self.exact_values.get('IAS', self.IASLineEdit.text()),
-                'altitude': self.exact_values.get('altitude', self.altitudeLineEdit.text()),
+                'IAS': self.IASSpinBox.value(),
+                'altitude': self.altitudeSpinBox.value(),
                 'altitude_unit': self.units.get('altitude', 'ft'),
                 'bankAngle': self.exact_values.get('bankAngle', self.bankAngleLineEdit.text()),
                 'w': self.exact_values.get('w', self.windSpeedLineEdit.text()),
@@ -503,8 +502,8 @@ class QPANSOPYWindSpiralDockWidgetBase(QtWidgets.QDockWidget, FORM_CLASS):
             azimuth = start_point.azimuth(end_point) + 180
 
             isa_var = float(self.isaVarLineEdit.text() or 0)
-            IAS = float(self.IASLineEdit.text() or 0)
-            altitude = float(self.altitudeLineEdit.text() or 0)
+            IAS = self.IASSpinBox.value()
+            altitude = self.altitudeSpinBox.value()
             if self.units.get('altitude', 'ft') == 'm':
                 altitude = altitude * 3.28084
             bank_angle = float(self.bankAngleLineEdit.text() or 0)
@@ -589,8 +588,8 @@ class QPANSOPYWindSpiralDockWidgetBase(QtWidgets.QDockWidget, FORM_CLASS):
         except Exception:
             isa_var = 0.0
 
-        IAS = self.exact_values.get('IAS', self.IASLineEdit.text())
-        altitude = self.exact_values.get('altitude', self.altitudeLineEdit.text())
+        IAS = self.IASSpinBox.value()
+        altitude = self.altitudeSpinBox.value()
         bankAngle = self.exact_values.get('bankAngle', self.bankAngleLineEdit.text())
         w = self.exact_values.get('w', self.windSpeedLineEdit.text())
         turn_direction = self.turnDirectionCombo.currentText()

--- a/Q_Pansopy/metadata.txt
+++ b/Q_Pansopy/metadata.txt
@@ -38,6 +38,7 @@ changelog=
  - Update PBN Target layer style: thinner outline (0.25mm) and add ARP-distance labels
  - Fix Basic ILS missed approach surface lateral half-width formula (was incorrectly using a flat 15% splay instead of the 14.3% transition-slope-derived offset), restoring parity with the reference script
  - Store all input parameters (DER elevation, PDG, TNA, MSA, CWY distance, options) as a JSON 'parameters' field on every OMNI SID output feature (areas, reference line, construction points)
+ - Replace Wind Spiral's IAS and Altitude text fields with spin boxes so arrow keys can nudge values and immediately see the impact on the live preview
  Version 0.4.0:
  - Fixes to initial realease to code logic including QGIS Plugin Store Compliance
  - PBN 15 NM and 30 NM targets included


### PR DESCRIPTION
# PR — Wind Spiral: replace IAS/Altitude inputs with spinners (Issue #199)

## Summary

Wind Spiral's "IAS (kt)" and "Altitude" fields are now `QSpinBox`es instead of `QLineEdit`s, so
their values can be nudged with the up/down arrows or the keyboard's arrow keys and immediately
see the effect on the live rubber-band preview.

## Implementation notes

- `IASSpinBox`: range 50–400 kt, default 205, step 1 — matches the existing
  `iasSpinBox` convention already used in `qpansopy_sid_initial_dockwidget.ui`.
- `altitudeSpinBox`: range 0–50000 ft, default 800, step 100 — matches the existing
  `tnaSpinBox`/`msaSpinBox` convention in `qpansopy_omnidirectional_dockwidget.ui`. The `ft`/`m`
  unit combo next to it is unchanged.
- Both wire `valueChanged` straight to the existing `_update_preview` live-preview handler.
- Simplified every place that read these two fields: since a spin box's `.value()` is always
  exact, the `store_exact_value()`/`exact_values['IAS'|'altitude']` bookkeeping this file uses
  elsewhere to avoid losing precision on a reformatted `QLineEdit` display no longer applies here
  — every read site now just calls `.value()` directly.

## Files Modified

| File | Change |
|---|---|
| `Q_Pansopy/dockwidgets/utilities/qpansopy_wind_spiral_dockwidget.py` | IAS/Altitude fields converted to `QSpinBox` |
| `Q_Pansopy/metadata.txt` | Changelog bullet |
| `docs/plan-199.md` | Implementation plan |

## Test plan

- [x] `pytest tests/ -q` — no regressions.
- [x] `flake8`/`bandit` — no new findings.
- [ ] In QGIS: open Wind Spiral, confirm both fields show as spin boxes; arrow keys / up-down
  buttons change the value and update the live preview; Calculate produces the same output as
  before for equivalent inputs.

## Related

Closes #199.
