### PR TITLE
SID Initial Climb inputs (Issue #204)

### DIFF
--- a/Q_Pansopy/dockwidgets/departures/qpansopy_sid_initial_dockwidget.py
+++ b/Q_Pansopy/dockwidgets/departures/qpansopy_sid_initial_dockwidget.py
@@ -66,6 +66,10 @@ class QPANSOPYSIDInitialDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         # Store exact values entered by user
         self.exact_values = {}
 
+        # ISA Variation: manual input or calculated from AD elevation + Temp (issue #204)
+        self.isa_calculation_metadata = {'method': 'calculated'}
+        self._isa_updating = False
+
         # Configure dock widget properties
         self.setFeatures(DOCK_FEATURES_DEFAULT)
 
@@ -83,6 +87,8 @@ class QPANSOPYSIDInitialDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         # Connect signals
         self.calculateButton.clicked.connect(self.calculate)
         self.directionButton.clicked.connect(self.toggle_direction)
+        self.isaVarSpinBox.valueChanged.connect(self._handle_isa_manual_change)
+        self.isaCalculateButton.clicked.connect(self._calculate_isa)
 
         # Setup copy buttons
         self.setup_copy_buttons()
@@ -171,6 +177,26 @@ class QPANSOPYSIDInitialDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
             level=Qgis.Success
         )
 
+    def _handle_isa_manual_change(self, _value):
+        """User typed directly into the ISA Variation field: mark it manual,
+        unless this change came from _calculate_isa()'s own setValue()."""
+        if not self._isa_updating:
+            self.isa_calculation_metadata['method'] = 'manual'
+
+    def _calculate_isa(self):
+        """Recompute ISA Variation from the current AD elevation + Temp fields
+        (issue #204: give the option to input manually or calculate)."""
+        from ...modules.departures.sid_initial_climb import calculate_isa_temperature
+        isa_values = calculate_isa_temperature(self.adElevSpinBox.value(), self.tempSpinBox.value())
+
+        self._isa_updating = True
+        try:
+            self.isaVarSpinBox.setValue(isa_values['delta_isa'])
+        finally:
+            self._isa_updating = False
+        self.isa_calculation_metadata['method'] = 'calculated'
+        self.log(f"ISA Variation calculated: {isa_values['delta_isa']:.4f}°C")
+
     def get_parameters(self):
         """
         Get current parameter values from UI.
@@ -183,6 +209,8 @@ class QPANSOPYSIDInitialDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
             'der_elevation_m': self.derElevSpinBox.value(),
             'pdg_percent': self.pdgSpinBox.value(),
             'reference_temp_c': self.tempSpinBox.value(),
+            'isa_var': self.isaVarSpinBox.value(),
+            'isa_source': self.isa_calculation_metadata['method'],
             'ias_kt': self.iasSpinBox.value(),
             'altitude_ft': self.altitudeSpinBox.value(),
             'bank_angle_deg': self.bankAngleSpinBox.value(),
@@ -244,6 +272,7 @@ class QPANSOPYSIDInitialDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         self.log(f"DER Elevation: {params['der_elevation_m']}m")
         self.log(f"PDG: {params['pdg_percent']}%")
         self.log(f"Temperature: {params['reference_temp_c']}°C")
+        self.log(f"ISA Variation: {params['isa_var']}°C ({params['isa_source']})")
         self.log(f"IAS: {params['ias_kt']}kt")
         self.log(f"Turn Altitude: {params['altitude_ft']}ft")
         self.log(f"Bank Angle: {params['bank_angle_deg']}°")

--- a/Q_Pansopy/metadata.txt
+++ b/Q_Pansopy/metadata.txt
@@ -39,6 +39,7 @@ changelog=
  - Fix Basic ILS missed approach surface lateral half-width formula (was incorrectly using a flat 15% splay instead of the 14.3% transition-slope-derived offset), restoring parity with the reference script
  - Store all input parameters (DER elevation, PDG, TNA, MSA, CWY distance, options) as a JSON 'parameters' field on every OMNI SID output feature (areas, reference line, construction points)
  - Replace Wind Spiral's IAS and Altitude text fields with spin boxes so arrow keys can nudge values and immediately see the impact on the live preview
+ - SID Initial Climb: use 4 decimal places on AD/DER elevation, PDG, Temp and Altitude fields, and add an ISA Variation field with a Calculate button (manual input or calculated from AD elevation + Temp, like Wind Spiral)
  Version 0.4.0:
  - Fixes to initial realease to code logic including QGIS Plugin Store Compliance
  - PBN 15 NM and 30 NM targets included

--- a/Q_Pansopy/modules/departures/sid_initial_climb.py
+++ b/Q_Pansopy/modules/departures/sid_initial_climb.py
@@ -243,11 +243,19 @@ def run_sid_initial_climb(iface, runway_layer, params, log_callback=None):
     # -------------------------------------------------------------------------
     # ISA and TAS calculations
     # -------------------------------------------------------------------------
-    isa_values = calculate_isa_temperature(aerodrome_elevation_m, reference_temp_c)
-    log(f"ISA deviation: {isa_values['delta_isa']:.2f}°C")
+    # ISA deviation is used directly when the dockwidget supplies it (manual
+    # input or the ISA Calculator button, issue #204) -- calculate_isa_temperature()
+    # is still the fallback for callers that only pass AD elevation + reference temp.
+    isa_var = params.get('isa_var')
+    if isa_var is not None:
+        delta_isa = float(isa_var)
+        log(f"ISA deviation (from params, {params.get('isa_source', 'unspecified')}): {delta_isa:.4f}°C")
+    else:
+        delta_isa = calculate_isa_temperature(aerodrome_elevation_m, reference_temp_c)['delta_isa']
+        log(f"ISA deviation (calculated from AD elevation + Temp): {delta_isa:.4f}°C")
 
     tas_values = calculate_tas_and_turn_parameters(
-        ias_kt, altitude_ft, isa_values['delta_isa'], bank_angle_deg, wind_kt
+        ias_kt, altitude_ft, delta_isa, bank_angle_deg, wind_kt
     )
     log(f"TAS: {tas_values['tas_kt']:.2f}kt, Rate of Turn: {tas_values['rate_of_turn']:.2f}°/s")
     log(f"Radius of Turn: {tas_values['radius_of_turn_nm']:.2f}NM")

--- a/Q_Pansopy/ui/departures/qpansopy_sid_initial_dockwidget.ui
+++ b/Q_Pansopy/ui/departures/qpansopy_sid_initial_dockwidget.ui
@@ -137,7 +137,7 @@
           <double>0.000000000000000</double>
          </property>
          <property name="decimals">
-          <number>2</number>
+          <number>4</number>
          </property>
         </widget>
        </item>
@@ -160,7 +160,7 @@
           <double>0.000000000000000</double>
          </property>
          <property name="decimals">
-          <number>2</number>
+          <number>4</number>
          </property>
         </widget>
        </item>
@@ -216,7 +216,7 @@
           <double>3.300000000000000</double>
          </property>
          <property name="decimals">
-          <number>2</number>
+          <number>4</number>
          </property>
         </widget>
        </item>
@@ -239,18 +239,58 @@
           <double>15.000000000000000</double>
          </property>
          <property name="decimals">
-          <number>1</number>
+          <number>4</number>
          </property>
         </widget>
        </item>
        <item row="2" column="0">
+        <widget class="QLabel" name="isaVarLabel">
+         <property name="text">
+          <string>ISA Variation (°C):</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <layout class="QHBoxLayout" name="isaVarLayout">
+         <item>
+          <widget class="QDoubleSpinBox" name="isaVarSpinBox">
+           <property name="minimum">
+            <double>-50.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>50.000000000000000</double>
+           </property>
+           <property name="decimals">
+            <number>4</number>
+           </property>
+           <property name="value">
+            <double>0.000000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="isaCalculateButton">
+           <property name="maximumWidth">
+            <number>34</number>
+           </property>
+           <property name="toolTip">
+            <string>Calculate ISA Variation from AD elevation + Temp</string>
+           </property>
+           <property name="text">
+            <string>🧮</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item row="3" column="0">
         <widget class="QLabel" name="iasLabel">
          <property name="text">
           <string>IAS (kt):</string>
          </property>
         </widget>
        </item>
-       <item row="2" column="1">
+       <item row="3" column="1">
         <widget class="QSpinBox" name="iasSpinBox">
          <property name="minimum">
           <number>50</number>
@@ -263,14 +303,14 @@
          </property>
         </widget>
        </item>
-       <item row="3" column="0">
+       <item row="4" column="0">
         <widget class="QLabel" name="altitudeLabel">
          <property name="text">
           <string>Alt (ft):</string>
          </property>
         </widget>
        </item>
-       <item row="3" column="1">
+       <item row="4" column="1">
         <widget class="QDoubleSpinBox" name="altitudeSpinBox">
          <property name="minimum">
           <double>100.000000000000000</double>
@@ -285,18 +325,18 @@
           <double>5000.000000000000000</double>
          </property>
          <property name="decimals">
-          <number>2</number>
+          <number>4</number>
          </property>
         </widget>
        </item>
-       <item row="4" column="0">
+       <item row="5" column="0">
         <widget class="QLabel" name="bankAngleLabel">
          <property name="text">
           <string>Bank (°):</string>
          </property>
         </widget>
        </item>
-       <item row="4" column="1">
+       <item row="5" column="1">
         <widget class="QSpinBox" name="bankAngleSpinBox">
          <property name="minimum">
           <number>5</number>
@@ -309,14 +349,14 @@
          </property>
         </widget>
        </item>
-       <item row="5" column="0">
+       <item row="6" column="0">
         <widget class="QLabel" name="windLabel">
          <property name="text">
           <string>Wind (kt):</string>
          </property>
         </widget>
        </item>
-       <item row="5" column="1">
+       <item row="6" column="1">
         <widget class="QSpinBox" name="windSpinBox">
          <property name="minimum">
           <number>0</number>
@@ -329,14 +369,14 @@
          </property>
         </widget>
        </item>
-       <item row="6" column="0">
+       <item row="7" column="0">
         <widget class="QLabel" name="pilotTimeLabel">
          <property name="text">
           <string>Pilot (s):</string>
          </property>
         </widget>
        </item>
-       <item row="6" column="1">
+       <item row="7" column="1">
         <widget class="QSpinBox" name="pilotTimeSpinBox">
          <property name="minimum">
           <number>1</number>


### PR DESCRIPTION
# PR — SID Initial Climb inputs (Issue #204)

## Summary

- AD/DER elevation, PDG, Temp, and Altitude fields now show 4 decimal places instead of 2 (Temp
  was 1).
- IAS confirmed already integer-only (`QSpinBox`, 50–400 kt) — no change needed there.
- New "ISA Variation (°C)" field + "🧮" calculate button: ISA deviation can now be typed in
  manually or (re)computed from AD elevation + Temp, instead of always being silently derived
  from those two fields on every run.

## Root cause

`run_sid_initial_climb()` always called `calculate_isa_temperature(aerodrome_elevation_m,
reference_temp_c)` with no way to override the result — there was no ISA input field at all, only
the two elevation/temperature inputs it derived from.

## Implementation notes

- Kept AD/DER/Temp fields as-is rather than removing them for a Wind-Spiral-style separate
  calculator dialog — `aerodrome_elevation_m` has no other use in this module besides the ISA
  calc, so adding a manual-override option directly next to the existing fields is the smaller
  change that still satisfies "manual or calculate".
- `isaVarSpinBox.valueChanged` marks the source as `'manual'`; a `_isa_updating` guard flag
  prevents the calculate button's own `setValue()` call from immediately re-marking itself
  manual.
- `run_sid_initial_climb()` prefers `params['isa_var']` when present, falling back to the
  original elevation+temp derivation only if absent — no behavior change for any other caller of
  this module.

## Files Modified

| File | Change |
|---|---|
| `Q_Pansopy/ui/departures/qpansopy_sid_initial_dockwidget.ui` | Decimals → 4 on 5 fields; new ISA Variation spin box + calculate button |
| `Q_Pansopy/dockwidgets/departures/qpansopy_sid_initial_dockwidget.py` | ISA manual/calculate wiring; `get_parameters()`/table updated |
| `Q_Pansopy/modules/departures/sid_initial_climb.py` | Uses `params['isa_var']` when supplied |
| `Q_Pansopy/metadata.txt` | Changelog bullet |
| `docs/plan-204.md` | Implementation plan |

## Test plan

- [x] `pytest tests/ -q` — no regressions (`tests/unit/test_sid.py` 16/16).
- [x] `flake8`/`bandit` — no new findings.
- [ ] In QGIS: confirm 4-decimal display on AD/DER/PDG/Temp/Altitude; IAS stays integer; typing
  into ISA Variation marks it manual; 🧮 recomputes and marks it calculated; Calculate uses the
  field's current value.

## Related

Closes #204.
