### PR TITLE
SID Initial layers grouped (Issue #207)

### DIFF
--- a/Q_Pansopy/metadata.txt
+++ b/Q_Pansopy/metadata.txt
@@ -39,6 +39,7 @@ changelog=
  - Fix Basic ILS missed approach surface lateral half-width formula (was incorrectly using a flat 15% splay instead of the 14.3% transition-slope-derived offset), restoring parity with the reference script
  - Store all input parameters (DER elevation, PDG, TNA, MSA, CWY distance, options) as a JSON 'parameters' field on every OMNI SID output feature (areas, reference line, construction points)
  - Replace Wind Spiral's IAS and Altitude text fields with spin boxes so arrow keys can nudge values and immediately see the impact on the live preview
+ - Group SID Initial Climb's 3 output layers (Protection Areas, Reference Line, Construction Lines) under a single 'SID Initial' layer tree group
  Version 0.4.0:
  - Fixes to initial realease to code logic including QGIS Plugin Store Compliance
  - PBN 15 NM and 30 NM targets included

--- a/Q_Pansopy/modules/departures/sid_initial_climb.py
+++ b/Q_Pansopy/modules/departures/sid_initial_climb.py
@@ -76,6 +76,26 @@ def point_with_z(point, z=0.0):
     return QgsPoint(point.x(), point.y(), z)
 
 
+def _get_or_create_layer_group(group_name):
+    """
+    Find a top-level layer tree group by name, creating it at the top of the
+    tree if it doesn't exist yet -- so repeated runs add layers into the same
+    group instead of creating "SID Initial (2)", "SID Initial (3)", etc.
+    (issue #207).
+
+    Args:
+        group_name (str): Name of the group.
+
+    Returns:
+        QgsLayerTreeGroup: The existing or newly created group.
+    """
+    root = QgsProject.instance().layerTreeRoot()
+    group = root.findGroup(group_name)
+    if group is None:
+        group = root.insertGroup(0, group_name)
+    return group
+
+
 # =============================================================================
 # CALCULATION FUNCTIONS
 # =============================================================================
@@ -337,6 +357,9 @@ def run_sid_initial_climb(iface, runway_layer, params, log_callback=None):
     log(f"Reference line half-width: {reference_half_width:.2f}m "
         f"({reference_half_width / 1852:.2f}NM)")
 
+    # Group all 3 output layers under a single "SID Initial" node (issue #207)
+    sid_group = _get_or_create_layer_group("SID Initial")
+
     # -------------------------------------------------------------------------
     # Create protection areas layer
     # -------------------------------------------------------------------------
@@ -371,7 +394,8 @@ def run_sid_initial_climb(iface, runway_layer, params, log_callback=None):
     areas_layer.renderer().symbol().setOpacity(0.7)
     areas_layer.triggerRepaint()
 
-    QgsProject.instance().addMapLayers([areas_layer])
+    QgsProject.instance().addMapLayers([areas_layer], False)
+    sid_group.insertLayer(0, areas_layer)
 
     # -------------------------------------------------------------------------
     # Create reference line layer
@@ -398,7 +422,8 @@ def run_sid_initial_climb(iface, runway_layer, params, log_callback=None):
     reference_line_layer.renderer().symbol().setWidth(0.5)
     reference_line_layer.triggerRepaint()
 
-    QgsProject.instance().addMapLayers([reference_line_layer])
+    QgsProject.instance().addMapLayers([reference_line_layer], False)
+    sid_group.insertLayer(0, reference_line_layer)
     log(f"Reference line layer added: {reference_line_layer_name}")
 
     # -------------------------------------------------------------------------
@@ -435,7 +460,8 @@ def run_sid_initial_climb(iface, runway_layer, params, log_callback=None):
     lines_layer.renderer().symbol().setWidth(0.5)
     lines_layer.triggerRepaint()
 
-    QgsProject.instance().addMapLayers([lines_layer])
+    QgsProject.instance().addMapLayers([lines_layer], False)
+    sid_group.insertLayer(0, lines_layer)
 
     # -------------------------------------------------------------------------
     # Zoom to result


### PR DESCRIPTION
# PR — SID Initial layers grouped (Issue #207)

## Summary

SID Initial Climb's 3 output layers now land inside a "SID Initial" group in the QGIS layer tree
instead of loose at the root, matching the order requested in the issue (top to bottom:
Construction Lines, Reference Line, Protection Areas).

## Implementation notes

- New `_get_or_create_layer_group(group_name)` reuses an existing top-level group by name if one
  already exists, rather than creating a new "SID Initial (2)" on every run.
- Each layer is now added with `addMapLayers([layer], False)` (skip the default root insertion)
  followed by `sid_group.insertLayer(0, layer)`. Inserting at index 0 in the existing
  areas → reference line → construction lines creation order naturally produces the requested
  final top-to-bottom order without needing to special-case it.

## Files Modified

| File | Change |
|---|---|
| `Q_Pansopy/modules/departures/sid_initial_climb.py` | Output layers grouped under "SID Initial" |
| `Q_Pansopy/metadata.txt` | Changelog bullet |
| `docs/plan-207.md` | Implementation plan |

## Test plan

- [x] `pytest tests/ -q` — no regressions.
- [x] `flake8`/`bandit` — 0 findings.
- [ ] In QGIS: run SID Initial Climb, confirm the "SID Initial" group and layer order match the
  issue's screenshot; run it again and confirm layers land in the same group.

## Related

Closes #207.
