### PR TITLE
Wind Spiral Parameters order (Issue #208)

### DIFF
--- a/Q_Pansopy/metadata.txt
+++ b/Q_Pansopy/metadata.txt
@@ -39,6 +39,7 @@ changelog=
  - Fix Basic ILS missed approach surface lateral half-width formula (was incorrectly using a flat 15% splay instead of the 14.3% transition-slope-derived offset), restoring parity with the reference script
  - Store all input parameters (DER elevation, PDG, TNA, MSA, CWY distance, options) as a JSON 'parameters' field on every OMNI SID output feature (areas, reference line, construction points)
  - Replace Wind Spiral's IAS and Altitude text fields with spin boxes so arrow keys can nudge values and immediately see the impact on the live preview
+ - Fix Wind Spiral and Omnidirectional SID stored 'parameters' JSON key order to match each tool's input field order
  Version 0.4.0:
  - Fixes to initial realease to code logic including QGIS Plugin Store Compliance
  - PBN 15 NM and 30 NM targets included

--- a/Q_Pansopy/modules/departures/omnidirectional_sid.py
+++ b/Q_Pansopy/modules/departures/omnidirectional_sid.py
@@ -213,6 +213,7 @@ def _build_omni_parameters_json(params, der_elevation_m, pdg_percent, tna_ft, ms
     from the data itself (issue #177) instead of only from the layer name.
     """
     parameters_dict = {
+        'reverse_direction': reverse_direction,
         'der_elevation_m': der_elevation_m,
         'der_elevation_unit': params.get('der_elevation_unit', 'm'),
         'pdg': pdg_percent,
@@ -222,7 +223,6 @@ def _build_omni_parameters_json(params, der_elevation_m, pdg_percent, tna_ft, ms
         'cwy_distance_unit': params.get('cwy_distance_unit', 'm'),
         'allow_turns_before_der': allow_turns_before_der,
         'include_construction_points': include_construction_points,
-        'reverse_direction': reverse_direction,
         'calculation_date': datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
         'calculation_type': 'Omnidirectional SID',
     }

--- a/Q_Pansopy/modules/wind_spiral.py
+++ b/Q_Pansopy/modules/wind_spiral.py
@@ -141,21 +141,24 @@ def _build_wind_spiral_parameters_json(IAS, altitude_ft, bankAngle, w, isa_var,
     isa_source = isa_calculation_metadata.get('method', 'manual')
 
     parameters_dict = {
-        'IAS': str(IAS),
-        'altitude': str(altitude_ft),
-        'altitude_unit': 'ft',
-        'bankAngle': str(bankAngle),
-        'w': str(w),
         'isa_var': str(round(isa_var, 2)),
         'isa_source': isa_source,
-        'turn_direction': turn_direction,
-        'calculation_date': datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
-        'calculation_type': 'Wind Spiral'
     }
     if isa_source == 'calculated':
         parameters_dict['isa_source_elevation'] = isa_calculation_metadata.get('elevation_original')
         parameters_dict['isa_source_elevation_unit'] = isa_calculation_metadata.get('elevation_unit')
         parameters_dict['isa_source_temp_ref'] = isa_calculation_metadata.get('temperature_reference')
+
+    parameters_dict.update({
+        'IAS': str(IAS),
+        'altitude': str(altitude_ft),
+        'altitude_unit': 'ft',
+        'bankAngle': str(bankAngle),
+        'w': str(w),
+        'turn_direction': turn_direction,
+        'calculation_date': datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+        'calculation_type': 'Wind Spiral'
+    })
 
     return json.dumps(parameters_dict)
 


### PR DESCRIPTION
# PR — Wind Spiral Parameters order (Issue #208)

## Summary

Stored `parameters` JSON keys now match each tool's UI input field order, so the Parameters
Inspector table reads in the same top-to-bottom order as the form the user filled in.

## Investigation

Audited every module that stores a `parameters` field (`basic_ils.py`, `oas_ils.py`,
`vss_straight.py`, `vss_loc.py`, `sid_initial_climb.py`'s `get_parameters()`, `wind_spiral.py`,
`omnidirectional_sid.py`) against its dockwidget's actual field order. Only two modules were
actually out of order:

- **Wind Spiral**: ISA Variation is the first field in the UI, but `isa_var`/`isa_source` were
  stored after `IAS`/`altitude`/`bankAngle`/`w`.
- **Omnidirectional SID**: Direction is the first control in the UI (above the Parameters group),
  but `reverse_direction` was stored last.

## Implementation notes

- `Q_Pansopy/modules/wind_spiral.py::_build_wind_spiral_parameters_json()`: `isa_var`/
  `isa_source` (plus the conditional `isa_source_*` detail keys, kept grouped right after
  `isa_source`) now come first, before `IAS`.
- `Q_Pansopy/modules/departures/omnidirectional_sid.py::_build_omni_parameters_json()`:
  `reverse_direction` now comes first, before `der_elevation_m`.
- No other module needed changes — their stored order already matched their UI order.
- `calculation_date`/`calculation_type` metadata keys stay last everywhere, matching the existing
  convention across all modules.

## Files Modified

| File | Change |
|---|---|
| `Q_Pansopy/modules/wind_spiral.py` | Reorder `parameters_dict` to put ISA fields first |
| `Q_Pansopy/modules/departures/omnidirectional_sid.py` | Reorder `parameters_dict` to put `reverse_direction` first |
| `Q_Pansopy/metadata.txt` | Changelog bullet |
| `docs/plan-208.md` | Implementation plan |

## Test plan

- [x] `pytest tests/ -q` — no regressions.
- [x] `flake8`/`bandit` — 0 findings.
- [ ] In QGIS: run Wind Spiral, open Parameters Inspector, confirm order is ISA Variation → IAS →
  Altitude → Bank Angle → Wind Speed → Turn Direction.
- [ ] In QGIS: run Omnidirectional SID, open Parameters Inspector, confirm Direction is the first
  row.

## Related

Closes #208.
