### PR TITLE
Wind Spiral Copy to Word (Issue #209)

### DIFF
--- a/Q_Pansopy/metadata.txt
+++ b/Q_Pansopy/metadata.txt
@@ -40,6 +40,7 @@ changelog=
  - Store all input parameters (DER elevation, PDG, TNA, MSA, CWY distance, options) as a JSON 'parameters' field on every OMNI SID output feature (areas, reference line, construction points)
  - Replace Wind Spiral's IAS and Altitude text fields with spin boxes so arrow keys can nudge values and immediately see the impact on the live preview
  - Group SID Initial Climb's 3 output layers (Protection Areas, Reference Line, Construction Lines) under a single 'SID Initial' layer tree group
+ - Redesign the Copy to Word parameters table: readable acronym-aware labels (e.g. Bank Angle, ISA Variation) and a compact black-and-white style instead of the blue/gray Word table
  Version 0.4.0:
  - Fixes to initial realease to code logic including QGIS Plugin Store Compliance
  - PBN 15 NM and 30 NM targets included

--- a/Q_Pansopy/utils.py
+++ b/Q_Pansopy/utils.py
@@ -241,6 +241,35 @@ def get_selected_feature(layer, show_error):
             return None
 
 
+_PARAM_LABEL_ACRONYMS = {
+    'IAS', 'ISA', 'PDG', 'TNA', 'MSA', 'CWY', 'DER', 'THR', 'OAS', 'FAP',
+    'MOC', 'VPA', 'OCH', 'RDH', 'ILS', 'KML', 'CRS', 'W',
+}
+
+_PARAM_LABEL_OVERRIDES = {
+    'isa_var': 'ISA Variation',
+}
+
+
+def _humanize_param_label(key):
+    """
+    Turn a raw parameters_dict key (snake_case or camelCase, sometimes with
+    aviation acronyms) into a readable label for the parameters table, e.g.
+    'bankAngle' -> 'Bank Angle', 'IAS' -> 'IAS', 'isa_source' -> 'ISA Source'
+    (issue #209 -- the previous naive `.replace('_', ' ').title()` mangled
+    both camelCase keys and existing acronym casing).
+    """
+    override = _PARAM_LABEL_OVERRIDES.get(key)
+    if override:
+        return override
+
+    spaced = re.sub(r'(?<=[a-z])(?=[A-Z])', ' ', str(key)).replace('_', ' ')
+    words = []
+    for word in spaced.split():
+        words.append(word.upper() if word.upper() in _PARAM_LABEL_ACRONYMS else word.capitalize())
+    return ' '.join(words)
+
+
 def format_parameters_table(title, params_dict, sections=None, as_html=False):
     """
     Format parameters as a standardized table for Word/text output.
@@ -325,25 +354,24 @@ def format_parameters_table(title, params_dict, sections=None, as_html=False):
         # Build simple HTML table with alternating row colors for Word
         html = []
         html.append(
-            '<table border="1" cellpadding="5" cellspacing="0"'
+            '<table border="1" cellpadding="4" cellspacing="0"'
             ' style="border-collapse: collapse; font-family: Calibri, Arial, sans-serif; font-size: 11pt;">'
         )
         html.append(
-            f'<tr style="background-color:#4472C4;color:white;font-weight:bold;text-align:center;">'
+            f'<tr style="background-color:#000000;color:#FFFFFF;font-weight:bold;text-align:center;">'
             f'<th colspan="3">{title}</th></tr>'
         )
         for sec in section_order:
             section_rows = [(p, v, u) for s, p, v, u in entries if s == sec]
-            html.append(f'<tr style="background-color:#D9E1F2;font-weight:bold;"><td colspan="3">{sec}</td></tr>')
+            html.append(f'<tr style="background-color:#FFFFFF;font-weight:bold;"><td colspan="3">{sec}</td></tr>')
             html.append(
-                '<tr style="background-color:#F2F2F2;font-weight:bold;">'
+                '<tr style="background-color:#FFFFFF;font-weight:bold;">'
                 '<td>Parameter</td><td>Value</td><td>Unit</td></tr>'
             )
-            for idx, (param_key, value, unit) in enumerate(section_rows):
-                bg = '#FFFFFF' if idx % 2 == 0 else '#F9F9F9'
-                param_name = str(param_key).replace('_', ' ').title()
+            for param_key, value, unit in section_rows:
+                param_name = _humanize_param_label(param_key)
                 html.append(
-                    f'<tr style="background-color:{bg};">'
+                    '<tr style="background-color:#FFFFFF;">'
                     f'<td>{param_name}</td><td style="text-align:right;">{value}</td><td>{unit}</td></tr>'
                 )
         html.append('</table>')
@@ -356,7 +384,7 @@ def format_parameters_table(title, params_dict, sections=None, as_html=False):
         table += "PARAMETER                    VALUE           UNIT\n"
         table += "-"*50 + "\n"
         for param_key, value, unit in section_rows:
-            param_name = str(param_key).replace('_', ' ').title()
+            param_name = _humanize_param_label(param_key)
             table += f"{param_name:<25} {str(value):<15} {unit}\n"
 
     return table

--- a/tests/integration/test_vss_tables.py
+++ b/tests/integration/test_vss_tables.py
@@ -18,7 +18,7 @@ def test_vss_straight_copy_parameters_table_header_and_rows():
     assert "QPANSOPY VSS STRAIGHT PARAMETERS" in table
     assert "Runway Data" in table
     assert "Approach Parameters" in table
-    assert "Thr Elev" in table or "Threshold Elevation" in table
+    assert "THR Elev" in table
 
 
 def test_vss_loc_copy_parameters_table_header_and_rows():


### PR DESCRIPTION
# PR — Wind Spiral Copy to Word (Issue #209)

## Summary

The "Copy to Word" parameters table now uses readable, acronym-aware labels and a compact
black-and-white style, instead of mangled labels (`Bankangle`, `Ias`, `Isa Var`) and a blue/gray
Word table that took up more vertical space than needed.

## Implementation notes

- This is shared code: every tool's "Copy to Word" (Wind Spiral, Basic ILS, OAS ILS, VSS, OMNI
  SID, SID Initial, Holding) goes through the same `format_parameters_table(..., as_html=True)`
  in `Q_Pansopy/utils.py`, so this fix improves all of them consistently, not just Wind Spiral.
- New `_humanize_param_label()` handles camelCase and snake_case keys and preserves a set of
  known aviation acronyms (IAS, ISA, PDG, TNA, MSA, CWY, DER, THR, OAS, FAP, MOC, VPA, OCH, RDH,
  ILS, KML, CRS, W) in upper case instead of naive title-casing them.
- `isa_var` gets an explicit override to `ISA Variation` (plain text, not the "Δ ISA" symbol from
  the issue's mockup, per request).
- HTML table: black header (was blue `#4472C4`), no blue/gray row fills, tighter `cellpadding`
  (5 -> 4). Plain-text (non-Word) table output only got the label fix, since its layout is
  monospace-column-based and unaffected by the HTML color complaint.

## Files Modified

| File | Change |
|---|---|
| `Q_Pansopy/utils.py` | New `_humanize_param_label()` helper; black-and-white Word table styling |
| `tests/integration/test_vss_tables.py` | Updated assertion for the corrected `THR Elev` label |
| `Q_Pansopy/metadata.txt` | Changelog bullet |
| `docs/plan-209.md` | Implementation plan |

## Test plan

- [x] `pytest tests/ -q` — no regressions.
- [x] `flake8`/`bandit` — 0 findings.
- [ ] In QGIS: run Wind Spiral, "Show Table" -> "Copy to Word", paste into Word, confirm the new
  black-and-white style and readable labels (IAS, Altitude, Bank Angle, W, ISA Variation, ISA
  Source, Turn Direction, Calculation Date, Calculation Type).
- [ ] Spot-check one other tool's Copy to Word (e.g. OAS ILS or SID Initial) to confirm it also
  picked up the new style/labels without breaking anything.

## Related

Closes #209.
