### PR TITLE
Combine VOR/NDB/LOC tolerance tools follow-up (Issue #181)

### DIFF
--- a/Q_Pansopy/dockwidgets/conv/qpansopy_dme_tolerance_dockwidget.py
+++ b/Q_Pansopy/dockwidgets/conv/qpansopy_dme_tolerance_dockwidget.py
@@ -20,24 +20,29 @@ FORM_CLASS, _ = uic.loadUiType(os.path.join(
 
 class QPANSOPYDMEToleranceDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
     """
-    Shared dockwidget for the VOR/DME, NDB/DME, and LOC/DME fix tolerance
-    tools. Subclasses only need to override NAV_TYPE, DEFAULT_ROTATE, and
-    POINT_LAYER_LABEL.
+    Dockwidget for the VOR/DME, NDB/DME, and LOC/DME fix tolerance tools.
+    Tolerance type is picked via toleranceTypeComboBox (issue #181 follow-up)
+    instead of separate dockwidget subclasses/instances, so switching type
+    keeps the selected layers and live preview instead of losing them.
     """
 
     closingPlugin = pyqtSignal()
 
-    NAV_TYPE = 'VOR/DME'
-    DEFAULT_ROTATE = 5.2
-    POINT_LAYER_LABEL = 'DME Point Layer'
+    # (nav_type, default_rotate, point_layer_label)
+    _TOLERANCE_TYPES = [
+        ('VOR/DME', 5.2, 'DME Point Layer'),
+        ('NDB/DME', 6.9, 'NDB Point Layer'),
+        ('LOC/DME', 2.4, 'LOC Point Layer'),
+    ]
 
     def __init__(self, iface):
         super().__init__(iface.mainWindow())
         self.setupUi(self)
         self.iface = iface
 
-        self.pointLayerLabel.setText(self.POINT_LAYER_LABEL)
-        self.rotateDoubleSpinBox.setValue(self.DEFAULT_ROTATE)
+        for nav_type, default_rotate, point_layer_label in self._TOLERANCE_TYPES:
+            self.toleranceTypeComboBox.addItem(nav_type, (default_rotate, point_layer_label))
+        self.toleranceTypeComboBox.currentIndexChanged.connect(self._on_tolerance_type_changed)
 
         self.pointLayerComboBox.setFilters(MLPM_PointLayer)
         self.fixLayerComboBox.setFilters(MLPM_PointLayer)
@@ -56,7 +61,14 @@ class QPANSOPYDMEToleranceDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         self.pointLayerComboBox.layerChanged.connect(self._on_layer_changed)
         self.fixLayerComboBox.layerChanged.connect(self._on_layer_changed)
         self.rotateDoubleSpinBox.valueChanged.connect(self._update_preview)
+
+        self._on_tolerance_type_changed()
         self._on_layer_changed()
+
+    def _on_tolerance_type_changed(self, *args):
+        default_rotate, point_layer_label = self.toleranceTypeComboBox.currentData()
+        self.pointLayerLabel.setText(point_layer_label)
+        self.rotateDoubleSpinBox.setValue(default_rotate)
 
     def closeEvent(self, event):
         self._clear_preview()
@@ -153,15 +165,16 @@ class QPANSOPYDMEToleranceDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
             self.iface.messageBar().pushMessage('QPANSOPY', msg, level=Qgis.Warning)
             return
 
-        params = {'rotate': self.rotateDoubleSpinBox.value(), 'nav_type': self.NAV_TYPE}
+        nav_type = self.toleranceTypeComboBox.currentText()
+        params = {'rotate': self.rotateDoubleSpinBox.value(), 'nav_type': nav_type}
 
         try:
-            self.log(f"Calculating {self.NAV_TYPE} Tolerance...")
+            self.log(f"Calculating {nav_type} Tolerance...")
             from ...modules.conv.dme_tolerance import run_dme_tolerance
             result = run_dme_tolerance(self.iface, navid_layer, fix_layer, params)
             if result:
                 self._clear_preview()
-                self.log(f"{self.NAV_TYPE} Tolerance calculation completed successfully")
+                self.log(f"{nav_type} Tolerance calculation completed successfully")
         except Exception as e:
             self.log(f"Error during calculation: {e}")
             import traceback

--- a/Q_Pansopy/dockwidgets/conv/qpansopy_loc_dme_tolerance_dockwidget.py
+++ b/Q_Pansopy/dockwidgets/conv/qpansopy_loc_dme_tolerance_dockwidget.py
@@ -1,8 +1,0 @@
-# -*- coding: utf-8 -*-
-from .qpansopy_dme_tolerance_dockwidget import QPANSOPYDMEToleranceDockWidget
-
-
-class QPANSOPYLOCDMEToleranceDockWidget(QPANSOPYDMEToleranceDockWidget):
-    NAV_TYPE = 'LOC/DME'
-    DEFAULT_ROTATE = 2.4
-    POINT_LAYER_LABEL = 'LOC Point Layer'

--- a/Q_Pansopy/dockwidgets/conv/qpansopy_ndb_dme_tolerance_dockwidget.py
+++ b/Q_Pansopy/dockwidgets/conv/qpansopy_ndb_dme_tolerance_dockwidget.py
@@ -1,8 +1,0 @@
-# -*- coding: utf-8 -*-
-from .qpansopy_dme_tolerance_dockwidget import QPANSOPYDMEToleranceDockWidget
-
-
-class QPANSOPYNDBDMEToleranceDockWidget(QPANSOPYDMEToleranceDockWidget):
-    NAV_TYPE = 'NDB/DME'
-    DEFAULT_ROTATE = 6.9
-    POINT_LAYER_LABEL = 'NDB Point Layer'

--- a/Q_Pansopy/dockwidgets/conv/qpansopy_vor_dme_tolerance_dockwidget.py
+++ b/Q_Pansopy/dockwidgets/conv/qpansopy_vor_dme_tolerance_dockwidget.py
@@ -1,8 +1,0 @@
-# -*- coding: utf-8 -*-
-from .qpansopy_dme_tolerance_dockwidget import QPANSOPYDMEToleranceDockWidget
-
-
-class QPANSOPYVORDMEToleranceDockWidget(QPANSOPYDMEToleranceDockWidget):
-    NAV_TYPE = 'VOR/DME'
-    DEFAULT_ROTATE = 5.2
-    POINT_LAYER_LABEL = 'DME Point Layer'

--- a/Q_Pansopy/metadata.txt
+++ b/Q_Pansopy/metadata.txt
@@ -41,6 +41,7 @@ changelog=
  - Replace Wind Spiral's IAS and Altitude text fields with spin boxes so arrow keys can nudge values and immediately see the impact on the live preview
  - Group SID Initial Climb's 3 output layers (Protection Areas, Reference Line, Construction Lines) under a single 'SID Initial' layer tree group
  - Redesign the Copy to Word parameters table: readable acronym-aware labels (e.g. Bank Angle, ISA Variation) and a compact black-and-white style instead of the blue/gray Word table
+ - Replace the VOR/DME, NDB/DME, LOC/DME dropdown-button tools with a single 'Create Tolerance' dockwidget with a Tolerance Type combo box, so switching type keeps the selected layers and live preview
  Version 0.4.0:
  - Fixes to initial realease to code logic including QGIS Plugin Store Compliance
  - PBN 15 NM and 30 NM targets included

--- a/Q_Pansopy/qpansopy.py
+++ b/Q_Pansopy/qpansopy.py
@@ -7,7 +7,7 @@ Copyright (C) 2020-2025 FLYGHT7
 import os
 from qgis.PyQt.QtCore import QSettings
 from qgis.PyQt.QtGui import QIcon, QGuiApplication
-from qgis.PyQt.QtWidgets import QAction, QMenu, QMessageBox, QSizePolicy, QToolButton
+from qgis.PyQt.QtWidgets import QAction, QMenu, QMessageBox, QSizePolicy
 from qgis.PyQt import sip
 from qgis.PyQt import QtWidgets, QtCore
 from qgis.core import QgsProject, QgsVectorLayer, QgsApplication, Qgis
@@ -22,7 +22,6 @@ from .qt_compat import (
     QTextEdit_WidgetWidth,
     QLayout_SetDefaultConstraint,
     Qt_Vertical,
-    QToolButton_InstantPopup,
 )
 
 
@@ -45,9 +44,7 @@ try:
     from .dockwidgets.conv.qpansopy_vor_dockwidget import QPANSOPYVORDockWidget
     from .dockwidgets.conv.qpansopy_ndb_dockwidget import QPANSOPYNDBDockWidget
     from .dockwidgets.conv.qpansopy_conv_initial_dockwidget import QPANSOPYConvInitialDockWidget
-    from .dockwidgets.conv.qpansopy_vor_dme_tolerance_dockwidget import QPANSOPYVORDMEToleranceDockWidget
-    from .dockwidgets.conv.qpansopy_ndb_dme_tolerance_dockwidget import QPANSOPYNDBDMEToleranceDockWidget
-    from .dockwidgets.conv.qpansopy_loc_dme_tolerance_dockwidget import QPANSOPYLOCDMEToleranceDockWidget
+    from .dockwidgets.conv.qpansopy_dme_tolerance_dockwidget import QPANSOPYDMEToleranceDockWidget
     from .dockwidgets.departures.qpansopy_sid_initial_dockwidget import QPANSOPYSIDInitialDockWidget
     from .dockwidgets.departures.qpansopy_omnidirectional_dockwidget import QPANSOPYOmnidirectionalDockWidget
     from .settings_dialog import SettingsDialog  # Import settings dialog
@@ -242,31 +239,12 @@ class Qpansopy:
                     "DOCK_WIDGET": QPANSOPYConvInitialDockWidget,
                     "GUI_INSTANCE": None
                 },
-                "VOR_DME_TOL": {
-                    "TITLE": "VOR/DME Tol",
+                "DME_TOL": {
+                    "TITLE": "Create Tolerance",
                     "TOOLBAR": "CONV",
-                    "TOOLTIP": "VOR/DME Tolerance Tool — sector × DME ring intersection",
-                    "ICON": os.path.join(self.icons_dir, 'vor_dme_tolerance.svg'),
-                    "DOCK_WIDGET": QPANSOPYVORDMEToleranceDockWidget,
-                    "GROUP": "DME_TOL",
-                    "GUI_INSTANCE": None
-                },
-                "NDB_DME_TOL": {
-                    "TITLE": "NDB/DME Tol",
-                    "TOOLBAR": "CONV",
-                    "TOOLTIP": "NDB/DME Tolerance Tool — sector × DME ring intersection",
-                    "ICON": os.path.join(self.icons_dir, 'ndb_dme_tolerance.svg'),
-                    "DOCK_WIDGET": QPANSOPYNDBDMEToleranceDockWidget,
-                    "GROUP": "DME_TOL",
-                    "GUI_INSTANCE": None
-                },
-                "LOC_DME_TOL": {
-                    "TITLE": "LOC/DME Tol",
-                    "TOOLBAR": "CONV",
-                    "TOOLTIP": "LOC/DME Tolerance Tool — sector × DME ring intersection",
-                    "ICON": os.path.join(self.icons_dir, 'loc_dme_tolerance.svg'),
-                    "DOCK_WIDGET": QPANSOPYLOCDMEToleranceDockWidget,
-                    "GROUP": "DME_TOL",
+                    "TOOLTIP": "DME Fix Tolerance Tool (VOR/DME, NDB/DME, LOC/DME) — sector × DME ring intersection",
+                    "ICON": os.path.join(self.icons_dir, 'dme_tolerance_group.svg'),
+                    "DOCK_WIDGET": QPANSOPYDMEToleranceDockWidget,
                     "GUI_INSTANCE": None
                 },
                 "ObjectSelection": {
@@ -323,16 +301,6 @@ class Qpansopy:
             # If you do not want empty submenus to be displayed self.submenus can be left as an empty dictionary
             self.submenus: dict = {"CONV": None, "ILS": None, "PBN": None, "UTILITIES": None, "DEPARTURES": None}
 
-            # Toolbar button groups: modules sharing a "GROUP" key are shown under a single
-            # dropdown QToolButton instead of one flat icon each (reduces toolbar clutter).
-            self.action_groups: dict = {
-                "DME_TOL": {
-                    "ICON": os.path.join(self.icons_dir, 'dme_tolerance_group.svg'),
-                    "TOOLTIP": "DME Tolerance (VOR/DME, NDB/DME, LOC/DME)",
-                },
-            }
-            self.group_buttons: dict = {}
-
             # Crear el menú QPANSOPY
             menuBar = self.iface.mainWindow().menuBar()
             self.menu = QMenu("QPANSOPY", self.iface.mainWindow())
@@ -381,23 +349,7 @@ class Qpansopy:
                     except Exception:
                         pass
                     self.toolbars[toolbar_name] = tb
-                group_id = properties.get("GROUP")
-                if group_id:
-                    if group_id not in self.group_buttons:
-                        group_info = self.action_groups.get(group_id, {})
-                        group_icon_path = group_info.get("ICON")
-                        if not group_icon_path or not os.path.exists(group_icon_path):
-                            group_icon_path = QgsApplication.iconPath(":missing_image.svg")
-                        btn = QToolButton(self.toolbars[toolbar_name])
-                        btn.setPopupMode(QToolButton_InstantPopup)
-                        btn.setIcon(QIcon(group_icon_path))
-                        btn.setToolTip(group_info.get("TOOLTIP", group_id))
-                        btn.setMenu(QMenu(btn))
-                        self.toolbars[toolbar_name].addWidget(btn)
-                        self.group_buttons[group_id] = btn
-                    self.group_buttons[group_id].menu().addAction(action)
-                else:
-                    self.toolbars[toolbar_name].addAction(action)
+                self.toolbars[toolbar_name].addAction(action)
                 self.actions.append(action)
                 if self.submenus.get(toolbar_name) is None:
                     self.submenus[toolbar_name] = QMenu(toolbar_name, self.menu)

--- a/Q_Pansopy/qt_compat.py
+++ b/Q_Pansopy/qt_compat.py
@@ -393,29 +393,6 @@ except AttributeError:
     QFormLayout_FieldsStayAtSizeHint = QFormLayout.FieldsStayAtSizeHint    # type: ignore[attr-defined]
     QFormLayout_ExpandingFieldsGrow = QFormLayout.ExpandingFieldsGrow      # type: ignore[attr-defined]
 
-# ---------------------------------------------------------------------------
-# Qt5/Qt6 compatible QTextEdit.LineWrapMode enum values
-#
-# Qt5: QTextEdit.WidgetWidth / QTextEdit.NoWrap  (unscoped)
-# Qt6: QTextEdit.LineWrapMode.WidgetWidth  (scoped)
-# ---------------------------------------------------------------------------
-try:
-    from qgis.PyQt.QtWidgets import QToolButton as _QToolButton  # noqa: F401
-except ImportError:
-    try:
-        from PyQt6.QtWidgets import QToolButton as _QToolButton  # noqa: F401
-    except ImportError:
-        from PyQt5.QtWidgets import QToolButton as _QToolButton  # noqa: F401
-
-try:
-    _tbpm = _QToolButton.ToolButtonPopupMode  # Qt6 scoped enum namespace
-    QToolButton_InstantPopup = _tbpm.InstantPopup
-    QToolButton_MenuButtonPopup = _tbpm.MenuButtonPopup
-    QToolButton_DelayedPopup = _tbpm.DelayedPopup
-except AttributeError:
-    QToolButton_InstantPopup = _QToolButton.InstantPopup            # type: ignore[attr-defined]
-    QToolButton_MenuButtonPopup = _QToolButton.MenuButtonPopup      # type: ignore[attr-defined]
-    QToolButton_DelayedPopup = _QToolButton.DelayedPopup            # type: ignore[attr-defined]
 
 try:
     _dbb = QDialogButtonBox.StandardButton  # Qt6 scoped enum namespace

--- a/Q_Pansopy/ui/conv/qpansopy_dme_tolerance_dockwidget.ui
+++ b/Q_Pansopy/ui/conv/qpansopy_dme_tolerance_dockwidget.ui
@@ -41,6 +41,23 @@
         <number>4</number>
        </property>
        <item>
+        <widget class="QLabel" name="toleranceTypeLabel">
+         <property name="text">
+          <string>Tolerance Type</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QComboBox" name="toleranceTypeComboBox">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QLabel" name="pointLayerLabel">
          <property name="text">
           <string>Navaid Point Layer</string>


### PR DESCRIPTION
# PR — Combine VOR/NDB/LOC tolerance tools follow-up (Issue #181)

## Summary

The DME fix tolerance tool (VOR/DME, NDB/DME, LOC/DME) is now a single dockwidget with a
"Tolerance Type" dropdown as its first field, replacing the previous 3-instance dropdown-button
setup from PR #189. Switching type no longer requires reselecting layers/parameters, and the live
preview no longer gets lost when switching between types.

## Implementation notes

- Most of the maintainer's follow-up was already satisfied by #189: `calculateButton` already
  reads "Create Tolerance", and `Sector_Angle` was already stored on the output layer. This PR is
  purely the UI/registration consolidation.
- `Q_Pansopy/ui/conv/qpansopy_dme_tolerance_dockwidget.ui`: added `toleranceTypeLabel` +
  `toleranceTypeComboBox` as the first field in `inputGroup`, above the point-layer combo.
- `Q_Pansopy/dockwidgets/conv/qpansopy_dme_tolerance_dockwidget.py`: dropped the
  `NAV_TYPE`/`DEFAULT_ROTATE`/`POINT_LAYER_LABEL` class-attribute-override pattern used by the 3
  subclasses. The combo box is now populated from a `_TOLERANCE_TYPES` list carrying each type's
  default sector angle and point-layer label; `_on_tolerance_type_changed()` updates the label and
  resets the sector angle to the new type's default (still freely editable afterwards, per the
  issue). `_update_preview()`/`calculate()` read the nav type from the combo box instead of a
  class attribute.
- Deleted the 3 now-redundant one-line dockwidget subclasses
  (`qpansopy_{vor,ndb,loc}_dme_tolerance_dockwidget.py`).
- `Q_Pansopy/qpansopy.py`: replaced the 3 `self.modules` entries with a single `DME_TOL` entry
  (reusing the existing `dme_tolerance_group.svg` icon). Since `DME_TOL` was the only consumer of
  the generic dropdown-button toolbar grouping mechanism (`GROUP`/`action_groups`/
  `group_buttons`), removed that now-dead code along with the `QToolButton`/
  `QToolButton_InstantPopup` imports it needed — including the now-unused `QToolButton` compat
  block in `Q_Pansopy/qt_compat.py` (confirmed unused anywhere else in the codebase).
- No changes needed to `Q_Pansopy/modules/conv/dme_tolerance.py` — already parameterized by
  `nav_type`/`rotate`.

## Files Modified

| File | Change |
|---|---|
| `Q_Pansopy/ui/conv/qpansopy_dme_tolerance_dockwidget.ui` | Add Tolerance Type combo as first field |
| `Q_Pansopy/dockwidgets/conv/qpansopy_dme_tolerance_dockwidget.py` | Combo-driven type switch |
| `Q_Pansopy/dockwidgets/conv/qpansopy_{vor,ndb,loc}_dme_tolerance_dockwidget.py` | Deleted |
| `Q_Pansopy/qpansopy.py` | One `DME_TOL` module entry; removed dead group-button mechanism |
| `Q_Pansopy/qt_compat.py` | Removed now-unused `QToolButton` compat constants |
| `Q_Pansopy/metadata.txt` | Changelog bullet |
| `docs/plan-181-followup.md` | Implementation plan |

## Test plan

- [x] `pytest tests/ -q` — no regressions (no existing tests reference the removed files/keys).
- [x] `flake8`/`bandit` — 0 new findings (bandit's 41 pre-existing `try/except pass` low findings
  are unchanged before/after, confirmed by diffing bandit output on `git stash`).
- [ ] In QGIS: CONV toolbar shows a single "Create Tolerance" icon (no more dropdown-button
  submenu). Opening it shows Tolerance Type as the first field. Switching between VOR/DME,
  NDB/DME, LOC/DME updates the point-layer label and default Sector Angle while keeping selected
  layers and the live preview intact. Running Calculate stores `Sector_Angle` correctly.

## Related

Follow-up to #181 / #189.
