### PR TITLE
Wind Spiral IAS should allow decimals (Issue #214)

### DIFF
--- a/Q_Pansopy/dockwidgets/utilities/qpansopy_wind_spiral_dockwidget.py
+++ b/Q_Pansopy/dockwidgets/utilities/qpansopy_wind_spiral_dockwidget.py
@@ -177,10 +177,12 @@ class QPANSOPYWindSpiralDockWidgetBase(QtWidgets.QDockWidget, FORM_CLASS):
 
         self.formLayout.addRow("ISA Variation (°C):", isa_container)
 
-        # IAS - spin box (integers) so arrow keys can nudge the live preview (issue #199)
-        self.IASSpinBox = QtWidgets.QSpinBox(self)
+        # IAS - decimal spin box so arrow keys nudge the live preview by 1 kt
+        # while still allowing fractional values (issue #214)
+        self.IASSpinBox = QtWidgets.QDoubleSpinBox(self)
         self.IASSpinBox.setRange(50, 400)
         self.IASSpinBox.setSingleStep(1)
+        self.IASSpinBox.setDecimals(1)
         self.IASSpinBox.setValue(205)
         self.IASSpinBox.valueChanged.connect(self._update_preview)
         self.IASSpinBox.setMinimumHeight(28)

--- a/Q_Pansopy/metadata.txt
+++ b/Q_Pansopy/metadata.txt
@@ -41,6 +41,7 @@ changelog=
  - Replace Wind Spiral's IAS and Altitude text fields with spin boxes so arrow keys can nudge values and immediately see the impact on the live preview
  - Group SID Initial Climb's 3 output layers (Protection Areas, Reference Line, Construction Lines) under a single 'SID Initial' layer tree group
  - Redesign the Copy to Word parameters table: readable acronym-aware labels (e.g. Bank Angle, ISA Variation) and a compact black-and-white style instead of the blue/gray Word table
+ - Wind Spiral IAS field now accepts decimal values (1 decimal place) instead of integers only, still nudged by 1 kt with the spinner arrows
  Version 0.4.0:
  - Fixes to initial realease to code logic including QGIS Plugin Store Compliance
  - PBN 15 NM and 30 NM targets included


### PR DESCRIPTION
# PR — Wind Spiral IAS should allow decimals (Issue #214)

## Summary

The Wind Spiral tool's IAS field is now a `QDoubleSpinBox` (1 decimal place) instead of an
integer-only `QSpinBox`, so fractional IAS values can be entered. The spinner arrow-key step
stays at 1 kt, per the issue's request.

## Implementation notes

- `Q_Pansopy/dockwidgets/utilities/qpansopy_wind_spiral_dockwidget.py`: `self.IASSpinBox` changed
  from `QtWidgets.QSpinBox` to `QtWidgets.QDoubleSpinBox`, with `setDecimals(1)` added. Range
  (50–400) and single step (1) unchanged.
- No other changes needed: every consumer of `self.IASSpinBox.value()` (live preview, `calculate()`,
  parameters JSON, Copy to Word/Parameters Inspector) already treats IAS as a float or casts it
  with `float(...)`, so `QDoubleSpinBox.value()` (which returns `float`) is a drop-in replacement.
  `Q_Pansopy/modules/wind_spiral.py` already does `IAS = float(params.get('IAS', 205))`.

## Files Modified

| File | Change |
|---|---|
| `Q_Pansopy/dockwidgets/utilities/qpansopy_wind_spiral_dockwidget.py` | IAS spin box: integer → decimal (1 dp) |
| `Q_Pansopy/metadata.txt` | Changelog bullet |

## Test plan

- [x] `pytest tests/ -q` — no regressions.
- [x] `flake8` — no new findings (pre-existing unused-import warnings in this file are unchanged).
- [ ] In QGIS: open Wind Spiral, confirm IAS field accepts e.g. `204.5`, spinner arrows still step
  by 1 kt, and the live preview / Calculate output reflect the decimal value correctly.

## Related

Closes #214.
